### PR TITLE
Fix copyright headers in xml files

### DIFF
--- a/dbus-vmstate1.xml
+++ b/dbus-vmstate1.xml
@@ -1,11 +1,10 @@
+<?xml version="1.0"?>
 <!--
 Copyright (c) 2021, Nutanix, Inc.
 
 Conntrack-Migrator v.1.0 is dual licensed under the BSD 3 Clause License or the
 GNU General Public License version 2.
 -->
-
-<?xml version="1.0"?>
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <interface name="org.qemu.VMState1">
     <property name="Id" type="s" access="read"/>

--- a/org.qemu.VMState1.conf
+++ b/org.qemu.VMState1.conf
@@ -1,3 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <!--
 Copyright (c) 2021, Nutanix, Inc.
 
@@ -6,10 +9,6 @@ Author: priyankar.jain@nutanix.com
 Conntrack-Migrator v.1.0 is dual licensed under the BSD 3 Clause License or the
 GNU General Public License version 2.
 -->
-
-<?xml version="1.0"?>
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
-        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
   <!--
     This configuration extends the system dbus configuration to allow


### PR DESCRIPTION
This commit fixes the copyright headers in the xml files so that they
can be parsed by a XML parser.
All copyright headers and comments in any XML file needs to be below the
<?xml version="1.0"?> line otherwise parser complains about the invalid
XML.

Signed-off-by: Priyankar Jain <priyankar.jain@nutanix.com>