### PR TITLE
Fixed race condition in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,15 @@ MAIN_SRCS := common.c \
 							lmct_config.c \
 							main.c
 
-DBUS_GENERATED := dbus_vmstate1.c
+DBUS_GENERATED := dbus_vmstate1.c dbus_vmstate1.h
 
 SRCS := $(addprefix $(SRC_DIR)/, $(MAIN_SRCS))
 GEN_SRCS := $(addprefix $(GEN_DIR)/, $(DBUS_GENERATED))
+GEN_C_SRCS := $(filter %.c, $(GEN_SRCS))
 
 
 OBJS := $(addprefix $(BUILD_DIR)/,$(SRCS:.c=.o))
-GEN_OBJS := $(addprefix $(BUILD_DIR)/,$(GEN_SRCS:.c=.o))
+GEN_OBJS := $(addprefix $(BUILD_DIR)/,$(GEN_C_SRCS:.c=.o))
 CONNTRACK_MIGRATOR := $(BUILD_DIR)/conntrack_migrator
 
 TEST_DIR := tests
@@ -99,10 +100,10 @@ $(GEN_DIR):
 $(GEN_SRCS): dbus-vmstate1.xml | $(GEN_DIR)
 	gdbus-codegen --interface-prefix org.qemu. --output-directory $(GEN_DIR) --generate-c-code dbus_vmstate1 --c-generate-object-manager $<
 
-$(BUILD_DIR_GEN)/%.o: $(GEN_DIR)/%.c $(GEN_SRCS)| $(BUILD_DIR_GEN)
+$(BUILD_DIR_GEN)/%.o: $(GEN_SRCS) | $(BUILD_DIR_GEN)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-$(BUILD_DIR_SRC)/%.o: $(SRC_DIR)/%.c $(GEN_SRCS)| $(BUILD_DIR_SRC)
+$(BUILD_DIR_SRC)/%.o: $(SRC_DIR)/%.c $(GEN_SRCS) | $(BUILD_DIR_SRC)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(CONNTRACK_MIGRATOR): $(GEN_OBJS) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ TEST_RUNNERS := $(addprefix $(TEST_RUNNER_DIR)/,$(MAIN_TEST_SRCS:.c=.out))
 
 .PHONY: all check clean clean_secondary setup_test_dbus
 
-all: $(GEN_SRC) $(CONNTRACK_MIGRATOR) ;
+all: $(GEN_SRCS) $(CONNTRACK_MIGRATOR) ;
 
 $(TEST_BUILD_DIR):
 	mkdir -p $@
@@ -99,10 +99,10 @@ $(GEN_DIR):
 $(GEN_SRCS): dbus-vmstate1.xml | $(GEN_DIR)
 	gdbus-codegen --interface-prefix org.qemu. --output-directory $(GEN_DIR) --generate-c-code dbus_vmstate1 --c-generate-object-manager $<
 
-$(BUILD_DIR_GEN)/%.o: $(GEN_DIR)/%.c | $(BUILD_DIR_GEN)
+$(BUILD_DIR_GEN)/%.o: $(GEN_DIR)/%.c $(GEN_SRCS)| $(BUILD_DIR_GEN)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-$(BUILD_DIR_SRC)/%.o: $(SRC_DIR)/%.c | $(BUILD_DIR_SRC)
+$(BUILD_DIR_SRC)/%.o: $(SRC_DIR)/%.c $(GEN_SRCS)| $(BUILD_DIR_SRC)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(CONNTRACK_MIGRATOR): $(GEN_OBJS) $(OBJS)


### PR DESCRIPTION
Following error was received when built with `make -j12`:
  src/dbus_server.c:33:53: fatal error: dbus_vmstate1.h: No such file or directory
  #include "dbus_vmstate1.h" // Will be auto-generated

Added a dependency on $(GEN_SRCS) for all .o build targets.

Signed-off-by: Priyankar Jain <priyankar.jain@nutanix.com>