### PR TITLE
conntrack_store: Make CT update event update processing atomic

### DIFF
--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -204,12 +204,10 @@ handle_update_event(struct conntrack_store *conn_store,
 
     if (res_ct_entry == NULL) {
         LOG(WARNING, "%s: received res_ct_entry as NULL", __func__);
-        goto finish;
+    } else {
+        g_hash_table_insert(conn_store->store, key, res_ct_entry);
     }
 
-    g_hash_table_insert(conn_store->store, key, res_ct_entry);
-
-finish:
     pthread_mutex_unlock(&conn_store->lock);
 }
 

--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -194,7 +194,6 @@ handle_update_event(struct conntrack_store *conn_store,
     const gpointer key = GUINT_TO_POINTER(ct_id);
     pthread_mutex_lock(&conn_store->lock);
     ct_entry = g_hash_table_lookup(conn_store->store, key);
-    pthread_mutex_unlock(&conn_store->lock);
     if (ct_entry == NULL) {
         LOG(VERBOSE, "%s: Update received for a non-existent entry. "
             "Treating it as NEW.", __func__);

--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -198,18 +198,19 @@ handle_update_event(struct conntrack_store *conn_store,
     if (ct_entry == NULL) {
         LOG(VERBOSE, "%s: Update received for a non-existent entry. "
             "Treating it as NEW.", __func__);
-        handle_new_event(conn_store, ct);
-        return;
+        res_ct_entry = conntrack_entry_from_nf_conntrack(ct);
+    } else {
+        res_ct_entry = get_conntrack_entry_from_update(ct_entry, ct);
     }
 
-    res_ct_entry = get_conntrack_entry_from_update(ct_entry, ct);
     if (res_ct_entry == NULL) {
         LOG(WARNING, "%s: received res_ct_entry as NULL", __func__);
-        return;
+        goto finish;
     }
 
-    pthread_mutex_lock(&conn_store->lock);
-    g_hash_table_replace(conn_store->store, key, res_ct_entry);
+    g_hash_table_insert(conn_store->store, key, res_ct_entry);
+
+finish:
     pthread_mutex_unlock(&conn_store->lock);
 }
 


### PR DESCRIPTION
There are 2 threads which are listening on CT events (one thread on the src IP based events, and the second thread based on the destination IP events).

There is a case in which both threads can receive the same conntrack event (update or delete). (CT entry's src and dst IP are both part of migratable IP given to the process.)

Now during processing of such an update following happens:

1. The current entry is looked up from the conntrack store.
2. A new entry is generated based on the current entry from CT store and the data we got from the event handler.
3. Finally the old/current entry is freed.

Step1, 2 and 3 are atomic amongst themselves but 1,2,3 is not an atomic operation as a whole.

There is a possibility that wrt threads T1 T2, following sequence of operations happens:

T1: 1, 2
T2: 1
T1: 3
T2: 2, 3

So when T2 performs 2, since the entry is already freed by T1 (at step-3) segmentation fault happens when T2 accesses that memory at its step-2.

This commit fixes it by making 1,2,3 an atomic operation as a whole.