### PR TITLE
[WIP] [FEAT-18702] LMCT - Supporting Zone Based Conntrack Migration

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          sudo apt install -y gcc libglib2.0-dev libmnl-dev libnetfilter-conntrack-dev check dbus
+          sudo apt install -y gcc libglib2.0-dev libmnl-dev libnetfilter-conntrack-dev uuid-dev check dbus
       - name: Build
         run: |
           make all
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          dnf --enablerepo=powertools install -y make gcc glib2-devel libmnl-devel libnetfilter_conntrack-devel check dbus
+          dnf --enablerepo=powertools install -y make gcc glib2-devel libmnl-devel libnetfilter_conntrack-devel libuuid-devel check dbus
       - name: Build
         run: |
           make all

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GLIB_LIBS := $(shell pkg-config --libs gio-2.0 glib-2.0 gobject-2.0 gio-unix-2.0
 LDLIBS := -lmnl \
 					-lnetfilter_conntrack \
 					-lpthread \
+					-luuid \
 					$(GLIB_LIBS)
 
 INCLUDE_DIRS := include/ \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Following libraries are required and can be easily installed using yum.
  - libnetfilter_conntrack, libnetfilter_conntrack-devel
  - libmnl, libmnl-devel
  - glib2, glib2-devel
+ - libuuid, libuuid-devel
  - gcc, make, gdbus-codegen
 
 ### Compile

--- a/dbus-vmstate1.xml
+++ b/dbus-vmstate1.xml
@@ -17,8 +17,11 @@ GNU General Public License version 2.
   </interface>
   <interface name="org.qemu.lmct.Mgmt">
     <property name="Id" type="s" access="read"/>
+    <!-- Payload shape depends on helper's SAVE mode (ct_del_args.kind):
+         IPs   : strv of IPv4 addresses still on this host.
+         Zones : flat paired strv [port_uuid, zone, ...] (even length). -->
     <method name="Clear">
-      <arg type="as" name="ip_address_list" direction="in"/>
+      <arg type="as" name="ips_or_zones_on_host" direction="in"/>
     </method>
   </interface>
 </node>

--- a/dbus-vmstate1.xml
+++ b/dbus-vmstate1.xml
@@ -17,7 +17,7 @@ GNU General Public License version 2.
   </interface>
   <interface name="org.qemu.lmct.Mgmt">
     <property name="Id" type="s" access="read"/>
-    <!-- Payload shape depends on helper's SAVE mode (ct_del_args.kind):
+    <!-- Payload shape depends on helper's SAVE mode (ct_del_args.op_type):
          IPs   : strv of IPv4 addresses still on this host.
          Zones : flat paired strv [port_uuid, zone, ...] (even length). -->
     <method name="Clear">

--- a/include/common.h
+++ b/include/common.h
@@ -52,6 +52,20 @@ struct save_targets {
     GHashTable *ports_to_migrate;
 };
 
+/**
+ * Bundle of LOAD-side migration policy. Tagged union over CLI sub-mode:
+ *   kind == LOAD_INPUT_LEGACY      -> zone_remap is NULL; pass-through.
+ *   kind == LOAD_INPUT_PORT_ZONES  -> zone_remap is uint16->uint16 map,
+ *                                     keyed by old_ct_zone, value is the
+ *                                     new_ct_zone to write before
+ *                                     programming each CT entry.
+ * Owned by load_targets and freed by load_targets_destroy.
+ */
+struct load_targets {
+    enum load_input_kind kind;
+    GHashTable *zone_remap;
+};
+
 GHashTable *
 create_hashtable_from_ip_list(const char *[], int);
 
@@ -75,5 +89,15 @@ save_targets_new_from_zones_and_ports(GHashTable *zones, GHashTable *ports);
 
 void
 save_targets_destroy(struct save_targets *);
+
+struct load_targets *
+load_targets_new_ips(void);
+
+struct load_targets *
+load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx,
+                                int stride);
+
+void
+load_targets_destroy(struct load_targets *);
 
 #endif /* COMMON_H */

--- a/include/common.h
+++ b/include/common.h
@@ -21,6 +21,28 @@
 #include <glib.h>
 
 /**
+ * Per-argument minimum values for ensure_cli_arg_is_int_at_least.
+ *
+ * Each constant names the CLI argument whose lower bound it enforces,
+ * so the call site reads as a domain-level statement instead of a
+ * magic number:
+ *
+ *   ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
+ *                                  MIN_ACCEPTABLE_VALUE_FOR_MODE);
+ *
+ * Rationale for the values:
+ *   - mode:        valid op-mode IDs start at 1 (the upper bound is
+ *                  separately enforced by check_mode()).
+ *   - num_entries: a zones/targets list of zero entries is not
+ *                  meaningful, so callers require at least one.
+ *   - num_ips:     zero is legitimate — it means "VM has no IPv4
+ *                  NICs" (start_in_save_mode early-exits in that case).
+ */
+ #define MIN_ACCEPTABLE_VALUE_FOR_MODE         1
+ #define MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES  1
+ #define MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS      0
+
+/**
  * Sub-mode tag: tells the rest of the daemon which SAVE-mode CLI layout
  * was detected from argv.
  */
@@ -90,27 +112,6 @@ is_valid_uuid_string(const char *);
 bool
 parse_ct_zone(const char *, uint16_t *);
 
-/**
- * Per-argument minimum values for ensure_cli_arg_is_int_at_least.
- *
- * Each constant names the CLI argument whose lower bound it enforces,
- * so the call site reads as a domain-level statement instead of a
- * magic number:
- *
- *   ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
- *                                  MIN_ACCEPTABLE_VALUE_FOR_MODE);
- *
- * Rationale for the values:
- *   - mode:        valid op-mode IDs start at 1 (the upper bound is
- *                  separately enforced by check_mode()).
- *   - num_entries: a zones/targets list of zero entries is not
- *                  meaningful, so callers require at least one.
- *   - num_ips:     zero is legitimate — it means "VM has no IPv4
- *                  NICs" (start_in_save_mode early-exits in that case).
- */
-#define MIN_ACCEPTABLE_VALUE_FOR_MODE         1
-#define MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES  1
-#define MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS      0
 
 /**
  * Ensures that a CLI argument string is an integer >= @min_value and

--- a/include/common.h
+++ b/include/common.h
@@ -66,6 +66,16 @@ struct load_targets {
     GHashTable *zone_remap;
 };
 
+/**
+ * Returns a human-readable, log-friendly name for a SAVE sub-mode.
+ *
+ * Used so log lines that fan out through both IP-mode and zone-mode
+ * paths can self-identify their mode without the operator having to
+ * grep backwards for the bootstrap banner.
+ */
+ const char *
+ save_input_kind_to_string(enum save_input_kind kind);
+ 
 GHashTable *
 create_hashtable_from_ip_list(const char *[], int);
 
@@ -80,6 +90,16 @@ create_hashtable_from_zone_and_port_list(const char *zones[],
                                          const char *port_uuids[],
                                          int n_entries,
                                          GHashTable **out_ports);
+
+/**
+ * Builds a uint16-keyed hashtable from a strv of decimal zone strings.
+ *
+ * Used by the zone-mode Clear D-Bus endpoint to translate the "zones
+ * still on this host" payload into a hashtable for the delete dump
+ * callback to look up against.
+ */
+GHashTable *
+create_hashtable_from_zone_str_list(const char *zones[], int num_entries);
 
 struct save_targets *
 save_targets_new_from_ips(GHashTable *ips_to_migrate);

--- a/include/common.h
+++ b/include/common.h
@@ -92,14 +92,22 @@ create_hashtable_from_zone_and_port_list(const char *zones[],
                                          GHashTable **out_ports);
 
 /**
- * Builds a uint16-keyed hashtable from a strv of decimal zone strings.
+ * Builds a uint16-keyed hashtable from a strv of paired
+ * [port_uuid_0, zone_0, port_uuid_1, zone_1, ...] elements.
  *
- * Used by the zone-mode Clear D-Bus endpoint to translate the "zones
- * still on this host" payload into a hashtable for the delete dump
- * callback to look up against.
+ * Used by the zone-mode Clear D-Bus endpoint to translate the
+ * "(port, zone) pairs still on this host" payload into a hashtable
+ * for the delete dump callback to look up against. The port_uuid half
+ * of each pair is treated as opaque metadata and intentionally
+ * ignored: the zone-mode delete path only filters on CT zone, so
+ * persisting the UUID buys us nothing past the parse step.
+ *
+ * @num_entries must be even; an odd count is a wire-protocol violation
+ * and the function will return NULL after logging.
  */
 GHashTable *
-create_hashtable_from_zone_str_list(const char *zones[], int num_entries);
+create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
+                                      int num_entries);
 
 struct save_targets *
 save_targets_new_from_ips(GHashTable *ips_to_migrate);

--- a/include/common.h
+++ b/include/common.h
@@ -73,8 +73,8 @@ struct load_targets {
  * paths can self-identify their mode without the operator having to
  * grep backwards for the bootstrap banner.
  */
- const char *
- save_input_kind_to_string(enum save_input_kind kind);
+const char *
+save_input_kind_to_string(enum save_input_kind kind);
  
 GHashTable *
 create_hashtable_from_ip_list(const char *[], int);

--- a/include/common.h
+++ b/include/common.h
@@ -85,6 +85,69 @@ is_valid_uuid_string(const char *);
 bool
 parse_ct_zone(const char *, uint16_t *);
 
+/**
+ * Per-argument minimum values for ensure_cli_arg_is_int_at_least.
+ *
+ * Each constant names the CLI argument whose lower bound it enforces,
+ * so the call site reads as a domain-level statement instead of a
+ * magic number:
+ *
+ *   ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
+ *                                  MIN_ACCEPTABLE_VALUE_FOR_MODE);
+ *
+ * Rationale for the values:
+ *   - mode:        valid op-mode IDs start at 1 (the upper bound is
+ *                  separately enforced by check_mode()).
+ *   - num_entries: a zones/targets list of zero entries is not
+ *                  meaningful, so callers require at least one.
+ *   - num_ips:     zero is legitimate — it means "VM has no IPv4
+ *                  NICs" (start_in_save_mode early-exits in that case).
+ */
+#define MIN_ACCEPTABLE_VALUE_FOR_MODE         1
+#define MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES  1
+#define MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS      0
+
+/**
+ * Ensures that a CLI argument string is an integer >= @min_value and
+ * writes the parsed value to *out_value on success.
+ *
+ * Stricter than atoi(): the full string must be a valid decimal
+ * number with no leading/trailing junk. Any of the following triggers
+ * errx(EXIT_FAILURE) with a message that names the offending argument:
+ *   - @arg_value is NULL or empty
+ *   - @arg_value contains non-numeric characters (e.g. "1xyz")
+ *   - @arg_value is less than @min_value or greater than INT_MAX
+ *
+ * The @min_value parameter lets the same helper enforce both
+ * "positive" (min_value = 1, for <N>-of-entries and <mode>) and
+ * "non-negative" (min_value = 0, for the legacy IP form's num_ips
+ * slot where 0 means "VM has no IPv4 NICs"; see the graceful
+ * early-exit in start_in_save_mode). min_value = 1 also subsumes the
+ * "n <= 0 silent fallback" branches that used to live in
+ * detect_save_input_kind.
+ *
+ * Designed for CLI argv slots where every existing caller treated
+ * bad input as a fatal error anyway. Folding the errx() into the
+ * helper avoids many copies of the same exit message and prevents
+ * the atoi() footgun of treating "1xyz" or "" as a successful parse.
+ *
+ * Note: this helper only enforces a lower bound. Value-set checks
+ * (e.g. mode must be 1 or 2) belong in a dedicated validator
+ * (check_mode) called immediately after this one.
+ *
+ * Args:
+ *   @arg_value the raw string from argv.
+ *   @out_value on success, set to the parsed int. Untouched on
+ *              failure (function does not return on failure).
+ *   @arg_name  display name for the argument, used in the error
+ *              message. Must be non-NULL.
+ *   @min_value lowest accepted value (inclusive). Typical values: 1
+ *              for "positive int", 0 for "non-negative int".
+ */
+void
+ensure_cli_arg_is_int_at_least(const char *arg_value, int *out_value,
+                               const char *arg_name, int min_value);
+
 GHashTable *
 create_hashtable_from_zone_and_port_list(const char *zones[],
                                          const char *port_uuids[],

--- a/include/common.h
+++ b/include/common.h
@@ -44,52 +44,55 @@
 
 /**
  * Sub-mode tag: tells the rest of the daemon which SAVE-mode CLI layout
- * was detected from argv.
+ * was detected from argv. Selects between IP-mode (filter CT entries by
+ * IPv4 src/dst) and zone-mode (filter by CT zone).
  */
-enum save_input_kind {
-    SAVE_INPUT_IPS,
-    SAVE_INPUT_PORT_ZONES
+enum save_mode_op_type {
+    SAVE_IPS_OP,
+    SAVE_PORT_ZONE_OP
 };
 
 /**
  * Sub-mode tag: tells the rest of the daemon which LOAD-mode CLI layout
- * was detected from argv.
+ * was detected from argv. Selects between IP-mode (legacy v1.0
+ * pass-through, no zone awareness) and zone-mode (apply src->dst zone
+ * rewrite before programming each CT entry).
  */
-enum load_input_kind {
-    LOAD_INPUT_LEGACY,
-    LOAD_INPUT_PORT_ZONES
+enum load_mode_op_type {
+    LOAD_IPS_OP,
+    LOAD_PORT_ZONE_OP
 };
 
 /**
- * SAVE-mode runtime config bundle. Real C tagged union over @kind:
- *   kind == SAVE_INPUT_IPS         -> ips_to_migrate is the active arm.
- *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate is the active arm.
+ * SAVE-mode runtime config bundle. Real C tagged union over @op_type:
+ *   op_type == SAVE_IPS_OP        -> ips_to_migrate is the active arm.
+ *   op_type == SAVE_PORT_ZONE_OP  -> zones_to_migrate is the active arm.
  * The active hashtable is owned by save_mode_config and freed by
- * destroy_save_mode_config (which dispatches on @kind because the two
+ * destroy_save_mode_config (which dispatches on @op_type because the two
  * pointer fields now overlay the same memory). Anonymous union so call
  * sites can keep using save_config->ips_to_migrate /
  * save_config->zones_to_migrate directly.
  */
 struct save_mode_config {
-    enum save_input_kind kind;
+    enum save_mode_op_type op_type;
     union {
-        GHashTable *ips_to_migrate;     /* kind == SAVE_INPUT_IPS */
-        GHashTable *zones_to_migrate;   /* kind == SAVE_INPUT_PORT_ZONES */
+        GHashTable *ips_to_migrate;     /* op_type == SAVE_IPS_OP       */
+        GHashTable *zones_to_migrate;   /* op_type == SAVE_PORT_ZONE_OP */
     };
 };
 
 /**
  * LOAD-mode runtime config bundle. Tagged union over CLI sub-mode:
- *   kind == LOAD_INPUT_LEGACY      -> src_dst_zone_map is NULL; pass-through.
- *   kind == LOAD_INPUT_PORT_ZONES  -> src_dst_zone_map is uint16->uint16
- *                                     map, keyed by old_ct_zone (source
- *                                     side), value is the new_ct_zone
- *                                     (destination side) to write before
- *                                     programming each CT entry.
+ *   op_type == LOAD_IPS_OP        -> src_dst_zone_map is NULL; pass-through.
+ *   op_type == LOAD_PORT_ZONE_OP  -> src_dst_zone_map is uint16->uint16
+ *                                    map, keyed by old_ct_zone (source
+ *                                    side), value is the new_ct_zone
+ *                                    (destination side) to write before
+ *                                    programming each CT entry.
  * Owned by load_mode_config and freed by destroy_load_mode_config.
  */
 struct load_mode_config {
-    enum load_input_kind kind;
+    enum load_mode_op_type op_type;
     GHashTable *src_dst_zone_map;
 };
 
@@ -101,7 +104,7 @@ struct load_mode_config {
  * grep backwards for the bootstrap banner.
  */
 const char *
-save_input_kind_to_string(enum save_input_kind kind);
+convert_save_mode_op_type_to_string(enum save_mode_op_type op_type);
  
 GHashTable *
 create_hashtable_from_ip_list(const char *const [], int);
@@ -130,7 +133,7 @@ parse_ct_zone(const char *, uint16_t *);
  * slot where 0 means "VM has no IPv4 NICs"; see the graceful
  * early-exit in start_in_save_mode). min_value = 1 also subsumes the
  * "n <= 0 silent fallback" branches that used to live in
- * detect_save_input_kind.
+ * detect_save_mode_op_type.
  *
  * Designed for CLI argv slots where every existing caller treated
  * bad input as a fatal error anyway. Folding the errx() into the

--- a/include/common.h
+++ b/include/common.h
@@ -186,8 +186,7 @@ struct load_targets *
 load_targets_new_ips(void);
 
 struct load_targets *
-load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx,
-                                int stride);
+load_targets_new_from_remap(GHashTable *remap);
 
 void
 load_targets_destroy(struct load_targets *);

--- a/include/common.h
+++ b/include/common.h
@@ -15,9 +15,65 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <glib.h>
+
+/**
+ * Sub-mode tag: tells the rest of the daemon which SAVE-mode CLI layout
+ * was detected from argv.
+ */
+enum save_input_kind {
+    SAVE_INPUT_IPS,
+    SAVE_INPUT_PORT_ZONES
+};
+
+/**
+ * Sub-mode tag: tells the rest of the daemon which LOAD-mode CLI layout
+ * was detected from argv.
+ */
+enum load_input_kind {
+    LOAD_INPUT_LEGACY,
+    LOAD_INPUT_PORT_ZONES
+};
+
+/**
+ * Bundle of SAVE-side migration targets. Tagged union over CLI sub-mode:
+ *   kind == SAVE_INPUT_IPS         -> ips_to_migrate is set
+ *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate and ports_to_migrate
+ *                                     are set
+ * All hashtables are owned by save_targets and freed by save_targets_destroy.
+ */
+struct save_targets {
+    enum save_input_kind kind;
+    GHashTable *ips_to_migrate;
+    GHashTable *zones_to_migrate;
+    GHashTable *ports_to_migrate;
+};
 
 GHashTable *
 create_hashtable_from_ip_list(const char *[], int);
+
+bool
+is_valid_uuid_string(const char *);
+
+bool
+parse_ct_zone(const char *, uint16_t *);
+
+GHashTable *
+create_hashtable_from_zone_and_port_list(const char *zones[],
+                                         const char *port_uuids[],
+                                         int n_entries,
+                                         GHashTable **out_ports);
+
+struct save_targets *
+save_targets_new_from_ips(GHashTable *ips_to_migrate);
+
+struct save_targets *
+save_targets_new_from_zones_and_ports(GHashTable *zones, GHashTable *ports);
+
+void
+save_targets_destroy(struct save_targets *);
 
 #endif /* COMMON_H */

--- a/include/common.h
+++ b/include/common.h
@@ -39,15 +39,21 @@ enum load_input_kind {
 };
 
 /**
- * Bundle of SAVE-side migration targets. Tagged union over CLI sub-mode:
- *   kind == SAVE_INPUT_IPS         -> ips_to_migrate is set
- *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate is set
- * All hashtables are owned by save_targets and freed by save_targets_destroy.
+ * Bundle of SAVE-side migration targets. Real C tagged union over @kind:
+ *   kind == SAVE_INPUT_IPS         -> ips_to_migrate is the active arm.
+ *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate is the active arm.
+ * The active hashtable is owned by save_targets and freed by
+ * save_targets_destroy (which dispatches on @kind because the two
+ * pointer fields now overlay the same memory). Anonymous union so call
+ * sites can keep using targets->ips_to_migrate / targets->zones_to_migrate
+ * directly.
  */
 struct save_targets {
     enum save_input_kind kind;
-    GHashTable *ips_to_migrate;
-    GHashTable *zones_to_migrate;
+    union {
+        GHashTable *ips_to_migrate;     /* kind == SAVE_INPUT_IPS */
+        GHashTable *zones_to_migrate;   /* kind == SAVE_INPUT_PORT_ZONES */
+    };
 };
 
 /**

--- a/include/common.h
+++ b/include/common.h
@@ -81,7 +81,7 @@ const char *
 save_input_kind_to_string(enum save_input_kind kind);
  
 GHashTable *
-create_hashtable_from_ip_list(const char *[], int);
+create_hashtable_from_ip_list(const char *const [], int);
 
 bool
 is_valid_uuid_string(const char *);
@@ -153,7 +153,7 @@ ensure_cli_arg_is_int_at_least(const char *arg_value, int *out_value,
                                const char *arg_name, int min_value);
 
 GHashTable *
-create_hashtable_from_zone_list(const char *zones[], int n_entries);
+create_hashtable_from_zone_list(const char *const zones[], int n_entries);
 
 /**
  * Builds a uint16-keyed hashtable from a strv of paired

--- a/include/common.h
+++ b/include/common.h
@@ -39,16 +39,16 @@ enum load_input_kind {
 };
 
 /**
- * Bundle of SAVE-side migration targets. Real C tagged union over @kind:
+ * SAVE-mode runtime config bundle. Real C tagged union over @kind:
  *   kind == SAVE_INPUT_IPS         -> ips_to_migrate is the active arm.
  *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate is the active arm.
- * The active hashtable is owned by save_targets and freed by
- * save_targets_destroy (which dispatches on @kind because the two
+ * The active hashtable is owned by save_mode_config and freed by
+ * destroy_save_mode_config (which dispatches on @kind because the two
  * pointer fields now overlay the same memory). Anonymous union so call
- * sites can keep using targets->ips_to_migrate / targets->zones_to_migrate
- * directly.
+ * sites can keep using save_config->ips_to_migrate /
+ * save_config->zones_to_migrate directly.
  */
-struct save_targets {
+struct save_mode_config {
     enum save_input_kind kind;
     union {
         GHashTable *ips_to_migrate;     /* kind == SAVE_INPUT_IPS */
@@ -57,17 +57,18 @@ struct save_targets {
 };
 
 /**
- * Bundle of LOAD-side migration policy. Tagged union over CLI sub-mode:
- *   kind == LOAD_INPUT_LEGACY      -> zone_remap is NULL; pass-through.
- *   kind == LOAD_INPUT_PORT_ZONES  -> zone_remap is uint16->uint16 map,
- *                                     keyed by old_ct_zone, value is the
- *                                     new_ct_zone to write before
+ * LOAD-mode runtime config bundle. Tagged union over CLI sub-mode:
+ *   kind == LOAD_INPUT_LEGACY      -> src_dst_zone_map is NULL; pass-through.
+ *   kind == LOAD_INPUT_PORT_ZONES  -> src_dst_zone_map is uint16->uint16
+ *                                     map, keyed by old_ct_zone (source
+ *                                     side), value is the new_ct_zone
+ *                                     (destination side) to write before
  *                                     programming each CT entry.
- * Owned by load_targets and freed by load_targets_destroy.
+ * Owned by load_mode_config and freed by destroy_load_mode_config.
  */
-struct load_targets {
+struct load_mode_config {
     enum load_input_kind kind;
-    GHashTable *zone_remap;
+    GHashTable *src_dst_zone_map;
 };
 
 /**
@@ -173,22 +174,22 @@ GHashTable *
 create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
                                       int num_entries);
 
-struct save_targets *
-save_targets_new_from_ips(GHashTable *ips_to_migrate);
+struct save_mode_config *
+create_save_mode_config_for_ip_mode(GHashTable *ips_to_migrate);
 
-struct save_targets *
-save_targets_new_from_zones(GHashTable *zones);
-
-void
-save_targets_destroy(struct save_targets *);
-
-struct load_targets *
-load_targets_new_ips(void);
-
-struct load_targets *
-load_targets_new_from_remap(GHashTable *remap);
+struct save_mode_config *
+create_save_mode_config_for_port_zone_mode(GHashTable *zones);
 
 void
-load_targets_destroy(struct load_targets *);
+destroy_save_mode_config(struct save_mode_config *);
+
+struct load_mode_config *
+create_load_mode_config_for_legacy_mode(void);
+
+struct load_mode_config *
+create_load_mode_config_for_port_zone_mode(GHashTable *src_dst_zone_map);
+
+void
+destroy_load_mode_config(struct load_mode_config *);
 
 #endif /* COMMON_H */

--- a/include/common.h
+++ b/include/common.h
@@ -41,15 +41,13 @@ enum load_input_kind {
 /**
  * Bundle of SAVE-side migration targets. Tagged union over CLI sub-mode:
  *   kind == SAVE_INPUT_IPS         -> ips_to_migrate is set
- *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate and ports_to_migrate
- *                                     are set
+ *   kind == SAVE_INPUT_PORT_ZONES  -> zones_to_migrate is set
  * All hashtables are owned by save_targets and freed by save_targets_destroy.
  */
 struct save_targets {
     enum save_input_kind kind;
     GHashTable *ips_to_migrate;
     GHashTable *zones_to_migrate;
-    GHashTable *ports_to_migrate;
 };
 
 /**
@@ -149,10 +147,7 @@ ensure_cli_arg_is_int_at_least(const char *arg_value, int *out_value,
                                const char *arg_name, int min_value);
 
 GHashTable *
-create_hashtable_from_zone_and_port_list(const char *zones[],
-                                         const char *port_uuids[],
-                                         int n_entries,
-                                         GHashTable **out_ports);
+create_hashtable_from_zone_list(const char *zones[], int n_entries);
 
 /**
  * Builds a uint16-keyed hashtable from a strv of paired
@@ -176,7 +171,7 @@ struct save_targets *
 save_targets_new_from_ips(GHashTable *ips_to_migrate);
 
 struct save_targets *
-save_targets_new_from_zones_and_ports(GHashTable *zones, GHashTable *ports);
+save_targets_new_from_zones(GHashTable *zones);
 
 void
 save_targets_destroy(struct save_targets *);

--- a/include/conntrack.h
+++ b/include/conntrack.h
@@ -22,6 +22,7 @@
 #include <libnetfilter_conntrack/libnetfilter_conntrack.h>
 #include <pthread.h>
 
+#include "common.h"
 #include "ct_delete_args.h"
 
 /**
@@ -29,17 +30,18 @@
  * the conntrack events.
  */
 struct ct_events_targs {
-    pthread_t tid;              // thread ID
-    GHashTable *ips_to_migrate; // IPs for which CT events needs to be listened
+    pthread_t tid;                  // thread ID
+    struct save_targets *targets;   // SAVE targets bundle (mode-aware)
     bool *stop_flag; // Flag when True, stop listening for CT events
     bool is_src; // Flag indicating whether the args are for src based events
 };
 
 int
-get_conntrack_dump(struct nfct_handle *, GHashTable *);
+get_conntrack_dump(struct nfct_handle *, struct save_targets *);
 
 int
-listen_for_conntrack_events(struct mnl_socket *, GHashTable *, bool, bool *);
+listen_for_conntrack_events(struct mnl_socket *, struct save_targets *,
+                            bool, bool *);
 
 void
 append_ct_to_batch(char *, struct nf_conntrack *, uint32_t *, int);

--- a/include/conntrack.h
+++ b/include/conntrack.h
@@ -30,17 +30,17 @@
  * the conntrack events.
  */
 struct ct_events_targs {
-    pthread_t tid;                  // thread ID
-    struct save_targets *targets;   // SAVE targets bundle (mode-aware)
+    pthread_t tid;                            // thread ID
+    struct save_mode_config *save_config;     // SAVE-mode config (mode-aware)
     bool *stop_flag; // Flag when True, stop listening for CT events
     bool is_src; // Flag indicating whether the args are for src based events
 };
 
 int
-get_conntrack_dump(struct nfct_handle *, struct save_targets *);
+get_conntrack_dump(struct nfct_handle *, struct save_mode_config *);
 
 int
-listen_for_conntrack_events(struct mnl_socket *, struct save_targets *,
+listen_for_conntrack_events(struct mnl_socket *, struct save_mode_config *,
                             bool, bool *);
 
 int

--- a/include/conntrack.h
+++ b/include/conntrack.h
@@ -43,7 +43,7 @@ int
 listen_for_conntrack_events(struct mnl_socket *, struct save_targets *,
                             bool, bool *);
 
-void
+int
 append_ct_to_batch(char *, struct nf_conntrack *, uint32_t *, int);
 
 int

--- a/include/conntrack_entry.h
+++ b/include/conntrack_entry.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <libnetfilter_conntrack/libnetfilter_conntrack.h>
 
+#include "common.h"
 #include "log.h"
 
 // Size of unsigned 32-bit integer
@@ -39,7 +40,7 @@
 #define CT_LABEL_NUM_WORDS 4
 
 // Total num of attributes we are using from nf_conntrack
-#define CT_ENTRY_NUM_ATTRIBUTES 21
+#define CT_ENTRY_NUM_ATTRIBUTES 25
 
 // Number of bits per byte
 #define BITS_PER_BYTE 8
@@ -72,6 +73,10 @@ enum conntrack_entry_attribute {
     CT_ATTR_MARK,                    // [uint32_t] CT mark metadata
     CT_ATTR_STATUS,                  // [uint32_t] CT status.(REPLIED/CONFIRMED/ASSURED..)
     CT_ATTR_LABEL,                   // [uint32_t[4]] CT label. 128 bits
+    CT_ATTR_L3_SRC_V4_REPL,          // [uint32_t] reply source ip address
+    CT_ATTR_L3_DST_V4_REPL,          // [uint32_t] reply destination ip address
+    CT_ATTR_L4_SRC_PORT_REPL,        // [uint16_t] reply source port
+    CT_ATTR_L4_DST_PORT_REPL,        // [uint16_t] reply destination port
     CT_ATTR_MAX                      // Attributes list end
 };
 
@@ -103,11 +108,12 @@ void
 conntrack_entry_destroy_g_wrapper(void *);
 
 struct conntrack_entry *
-conntrack_entry_from_nf_conntrack(struct nf_conntrack *);
+conntrack_entry_from_nf_conntrack(struct nf_conntrack *, enum save_input_kind);
 
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *,
-                                struct nf_conntrack *);
+                                struct nf_conntrack *,
+                                enum save_input_kind);
 
 bool
 is_set_in_bitmap(uint32_t *, uint8_t);

--- a/include/conntrack_entry.h
+++ b/include/conntrack_entry.h
@@ -108,11 +108,11 @@ void
 conntrack_entry_destroy_g_wrapper(void *);
 
 struct conntrack_entry *
-conntrack_entry_from_nf_conntrack(struct nf_conntrack *, enum save_input_kind);
+conntrack_entry_from_nf_conntrack(const struct nf_conntrack *, enum save_input_kind);
 
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *,
-                                struct nf_conntrack *,
+                                const struct nf_conntrack *,
                                 enum save_input_kind);
 
 bool

--- a/include/conntrack_entry.h
+++ b/include/conntrack_entry.h
@@ -170,12 +170,12 @@ void
 conntrack_entry_destroy_g_wrapper(void *);
 
 struct conntrack_entry *
-conntrack_entry_from_nf_conntrack(const struct nf_conntrack *, enum save_input_kind);
+conntrack_entry_from_nf_conntrack(const struct nf_conntrack *, enum save_mode_op_type);
 
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *,
                                 const struct nf_conntrack *,
-                                enum save_input_kind);
+                                enum save_mode_op_type);
 
 bool
 is_set_in_bitmap(uint32_t *, uint8_t);

--- a/include/conntrack_entry.h
+++ b/include/conntrack_entry.h
@@ -39,8 +39,15 @@
 // Number of words in CT Label
 #define CT_LABEL_NUM_WORDS 4
 
-// Total num of attributes we are using from nf_conntrack
-#define CT_ENTRY_NUM_ATTRIBUTES 25
+/* Size of the v1.0 wire schema (slots 0..20 of enum
+ * conntrack_entry_attribute). v1.1 appended four NAT'd-reply slots
+ * (21..24) for zone-mode; IP mode keeps emitting only the legacy
+ * subset so a v1.0 receiver remains a valid LOAD target. This
+ * constant MUST stay at 21 -- the static asserts below will fail
+ * the build if a future enum edit accidentally invalidates the
+ * contract. Bump only as part of a coordinated wire-schema-rev
+ * change. */
+#define CT_ATTR_LEGACY_NUM_BITS 21
 
 // Number of bits per byte
 #define BITS_PER_BYTE 8
@@ -79,6 +86,61 @@ enum conntrack_entry_attribute {
     CT_ATTR_L4_DST_PORT_REPL,        // [uint16_t] reply destination port
     CT_ATTR_MAX                      // Attributes list end
 };
+
+/* Wire-compat lock for v1.0/v1.1 mixed-version migrations.
+ *
+ * Every slot in enum conntrack_entry_attribute is pinned to a fixed
+ * integer position because that position is the bit_num that travels
+ * on the wire. Any insertion, deletion, reorder, or in-place swap
+ * silently corrupts mixed-version migrations -- the bytes parse
+ * with the wrong semantics on the receiver, with no error logged.
+ *
+ * Slots 0..CT_ATTR_LEGACY_NUM_BITS-1 are the v1.0 wire schema and
+ * are baked into every v1.0 binary in the field. Slots
+ * CT_ATTR_LEGACY_NUM_BITS..CT_ATTR_MAX-1 were appended for zone-mode
+ * NAT'd-reply support; they are absent on v1.0 receivers but pinned
+ * here so future v1.x reorderings can't desync v1.1 <-> v1.x
+ * zone-mode payloads either.
+ *
+ * If you really are revving the wire schema, do it as a coordinated
+ * change with the receiver-side migration path and bump
+ * CT_ATTR_LEGACY_NUM_BITS / CT_ATTR_MAX deliberately. */
+
+/* Legacy v1.0 wire slots. */
+_Static_assert(CT_ATTR_L3_SRC_V4            ==  0, "v1.0 wire slot 0 pinned");
+_Static_assert(CT_ATTR_L3_DST_V4            ==  1, "v1.0 wire slot 1 pinned");
+_Static_assert(CT_ATTR_L3_PROTONUM          ==  2, "v1.0 wire slot 2 pinned");
+_Static_assert(CT_ATTR_PROTONUM             ==  3, "v1.0 wire slot 3 pinned");
+_Static_assert(CT_ATTR_ZONE                 ==  4, "v1.0 wire slot 4 pinned");
+_Static_assert(CT_ATTR_L4_SRC_PORT          ==  5, "v1.0 wire slot 5 pinned");
+_Static_assert(CT_ATTR_L4_DST_PORT          ==  6, "v1.0 wire slot 6 pinned");
+_Static_assert(CT_ATTR_ICMP_SRC_ID          ==  7, "v1.0 wire slot 7 pinned");
+_Static_assert(CT_ATTR_ICMP_DST_TYPE        ==  8, "v1.0 wire slot 8 pinned");
+_Static_assert(CT_ATTR_ICMP_DST_CODE        ==  9, "v1.0 wire slot 9 pinned");
+_Static_assert(CT_ATTR_TCP_STATE            == 10, "v1.0 wire slot 10 pinned");
+_Static_assert(CT_ATTR_TCP_ORIG_FLAGS_VALUE == 11, "v1.0 wire slot 11 pinned");
+_Static_assert(CT_ATTR_TCP_ORIG_FLAGS_MASK  == 12, "v1.0 wire slot 12 pinned");
+_Static_assert(CT_ATTR_TCP_ORIG_WSCALE      == 13, "v1.0 wire slot 13 pinned");
+_Static_assert(CT_ATTR_TCP_REPL_FLAGS_VALUE == 14, "v1.0 wire slot 14 pinned");
+_Static_assert(CT_ATTR_TCP_REPL_FLAGS_MASK  == 15, "v1.0 wire slot 15 pinned");
+_Static_assert(CT_ATTR_TCP_REPL_WSCALE      == 16, "v1.0 wire slot 16 pinned");
+_Static_assert(CT_ATTR_TIMEOUT              == 17, "v1.0 wire slot 17 pinned");
+_Static_assert(CT_ATTR_MARK                 == 18, "v1.0 wire slot 18 pinned");
+_Static_assert(CT_ATTR_STATUS               == 19, "v1.0 wire slot 19 pinned");
+_Static_assert(CT_ATTR_LABEL                == 20, "v1.0 wire slot 20 pinned");
+
+/* Zone-mode NAT'd-reply slots. */
+_Static_assert(CT_ATTR_L3_SRC_V4_REPL       == 21, "zone wire slot 21 pinned");
+_Static_assert(CT_ATTR_L3_DST_V4_REPL       == 22, "zone wire slot 22 pinned");
+_Static_assert(CT_ATTR_L4_SRC_PORT_REPL     == 23, "zone wire slot 23 pinned");
+_Static_assert(CT_ATTR_L4_DST_PORT_REPL     == 24, "zone wire slot 24 pinned");
+
+/* Macro pins -- catch the cases the per-slot pins can't: drifting
+ * the macro value, or appending a new attribute past slot 24. */
+_Static_assert(CT_ATTR_LEGACY_NUM_BITS == 21,
+               "v1.0 wire schema is locked at 21 attrs");
+_Static_assert(CT_ATTR_MAX == 25,
+               "current schema rev pinned; bump intentionally");
 
 // Mapping from CT entry attribute to its size.
 // Useful when converting the nf_conntrack entry

--- a/include/conntrack_store.h
+++ b/include/conntrack_store.h
@@ -20,6 +20,8 @@
 
 #include <libnetfilter_conntrack/libnetfilter_conntrack.h>
 
+#include "common.h"
+
 /**
  * Represents the hashtable to store the conntrack entries received from the
  * kernel.
@@ -39,6 +41,6 @@ conntrack_store_destroy(struct conntrack_store *);
 
 void
 update_conntrack_store(struct conntrack_store *, struct nf_conntrack *,
-                       enum nf_conntrack_msg_type);
+                       enum nf_conntrack_msg_type, enum save_input_kind);
 
 #endif /* CONNTRACK_STORE_H */

--- a/include/conntrack_store.h
+++ b/include/conntrack_store.h
@@ -40,7 +40,7 @@ void
 conntrack_store_destroy(struct conntrack_store *);
 
 void
-update_conntrack_store(struct conntrack_store *, struct nf_conntrack *,
+update_conntrack_store(struct conntrack_store *, const struct nf_conntrack *,
                        enum nf_conntrack_msg_type, enum save_input_kind);
 
 #endif /* CONNTRACK_STORE_H */

--- a/include/conntrack_store.h
+++ b/include/conntrack_store.h
@@ -41,6 +41,6 @@ conntrack_store_destroy(struct conntrack_store *);
 
 void
 update_conntrack_store(struct conntrack_store *, const struct nf_conntrack *,
-                       enum nf_conntrack_msg_type, enum save_input_kind);
+                       enum nf_conntrack_msg_type, enum save_mode_op_type);
 
 #endif /* CONNTRACK_STORE_H */

--- a/include/ct_delete_args.h
+++ b/include/ct_delete_args.h
@@ -30,8 +30,8 @@
  * (the two pairs overlay the same memory; only the active arm is set.)
  *
  * Ownership:
- *   - ips_migrated / zones_migrated are aliases into save_targets and must
- *     not be freed by the delete thread.
+ *   - ips_migrated / zones_migrated are aliases into save_mode_config and
+ *     must not be freed by the delete thread.
  *   - ips_on_host / zones_on_host are built by on_clear and consumed by
  *     the delete thread; they are released alongside process exit since
  *     the daemon is short-lived.

--- a/include/ct_delete_args.h
+++ b/include/ct_delete_args.h
@@ -25,8 +25,8 @@
  * successful migration.
  *
  * Real C tagged union over the active SAVE sub-mode:
- *   kind == SAVE_INPUT_IPS         -> ips_migrated / ips_on_host valid.
- *   kind == SAVE_INPUT_PORT_ZONES  -> zones_migrated / zones_on_host valid.
+ *   op_type == SAVE_IPS_OP        -> ips_migrated / ips_on_host valid.
+ *   op_type == SAVE_PORT_ZONE_OP  -> zones_migrated / zones_on_host valid.
  * (the two pairs overlay the same memory; only the active arm is set.)
  *
  * Ownership:
@@ -37,9 +37,9 @@
  *     the daemon is short-lived.
  */
 struct ct_delete_args {
-    pthread_t tid;             // Represents the thread ID
-    enum save_input_kind kind; // Active SAVE sub-mode; selects which arm
-                               // of the union below is valid.
+    pthread_t tid;                   // Represents the thread ID
+    enum save_mode_op_type op_type;  // Active SAVE sub-mode; selects which arm
+                                     // of the union below is valid.
 
     /* Active sub-mode state. Anonymous outer union forces mutual
      * exclusion (a SAVE mode is either IP-list-driven or port-zone-
@@ -48,12 +48,12 @@ struct ct_delete_args {
      *   ct_del_args.ips_migrated, ct_del_args.zones_on_host, etc.
      */
     union {
-        /* kind == SAVE_INPUT_IPS */
+        /* op_type == SAVE_IPS_OP */
         struct {
             GHashTable *ips_migrated;  // IP addresses migrated from this host
             GHashTable *ips_on_host;   // IP addresses currently on this host
         };
-        /* kind == SAVE_INPUT_PORT_ZONES */
+        /* op_type == SAVE_PORT_ZONE_OP */
         struct {
             GHashTable *zones_migrated; // CT zones migrated from this host
             GHashTable *zones_on_host;  // CT zones currently owned by ports on this host

--- a/include/ct_delete_args.h
+++ b/include/ct_delete_args.h
@@ -21,13 +21,33 @@
 
 /**
  * Represents the arguments to be passed to the thread responsible
- * for cleanining up the conntrack entries in source hypervisor upon
+ * for cleaning up the conntrack entries in source hypervisor upon
  * successful migration.
+ *
+ * Tagged union over the active SAVE sub-mode:
+ *   kind == SAVE_INPUT_IPS         -> ips_migrated / ips_on_host valid.
+ *   kind == SAVE_INPUT_PORT_ZONES  -> zones_migrated / zones_on_host valid.
+ *
+ * Ownership:
+ *   - ips_migrated / zones_migrated are aliases into save_targets and must
+ *     not be freed by the delete thread.
+ *   - ips_on_host / zones_on_host are built by on_clear and consumed by
+ *     the delete thread; they are released alongside process exit since
+ *     the daemon is short-lived.
  */
 struct ct_delete_args {
     pthread_t tid;             // Represents the thread ID
+    enum save_input_kind kind; // Active SAVE sub-mode; selects which set
+                               // of pointers below is valid.
+
+    /* IP-mode state */
     GHashTable *ips_migrated;  // IP addresses migrated from this host
     GHashTable *ips_on_host;   // IP addresses currently on this host
+
+    /* Zone-mode state */
+    GHashTable *zones_migrated; // CT zones migrated from this host
+    GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
+
     bool clear_called;         // Flag to indicate if clear DBUS IPC is invoked
     pthread_mutex_t mutex;            // mutex for the condition var
     pthread_cond_t clear_called_cond; // Condition to wait until the clear IPC is called

--- a/include/ct_delete_args.h
+++ b/include/ct_delete_args.h
@@ -24,9 +24,10 @@
  * for cleaning up the conntrack entries in source hypervisor upon
  * successful migration.
  *
- * Tagged union over the active SAVE sub-mode:
+ * Real C tagged union over the active SAVE sub-mode:
  *   kind == SAVE_INPUT_IPS         -> ips_migrated / ips_on_host valid.
  *   kind == SAVE_INPUT_PORT_ZONES  -> zones_migrated / zones_on_host valid.
+ * (the two pairs overlay the same memory; only the active arm is set.)
  *
  * Ownership:
  *   - ips_migrated / zones_migrated are aliases into save_targets and must
@@ -37,16 +38,27 @@
  */
 struct ct_delete_args {
     pthread_t tid;             // Represents the thread ID
-    enum save_input_kind kind; // Active SAVE sub-mode; selects which set
-                               // of pointers below is valid.
+    enum save_input_kind kind; // Active SAVE sub-mode; selects which arm
+                               // of the union below is valid.
 
-    /* IP-mode state */
-    GHashTable *ips_migrated;  // IP addresses migrated from this host
-    GHashTable *ips_on_host;   // IP addresses currently on this host
-
-    /* Zone-mode state */
-    GHashTable *zones_migrated; // CT zones migrated from this host
-    GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
+    /* Active sub-mode state. Anonymous outer union forces mutual
+     * exclusion (a SAVE mode is either IP-list-driven or port-zone-
+     * driven, never both), but the inner structs are anonymous so
+     * field access stays flat:
+     *   ct_del_args.ips_migrated, ct_del_args.zones_on_host, etc.
+     */
+    union {
+        /* kind == SAVE_INPUT_IPS */
+        struct {
+            GHashTable *ips_migrated;  // IP addresses migrated from this host
+            GHashTable *ips_on_host;   // IP addresses currently on this host
+        };
+        /* kind == SAVE_INPUT_PORT_ZONES */
+        struct {
+            GHashTable *zones_migrated; // CT zones migrated from this host
+            GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
+        };
+    };
 
     bool clear_called;         // Flag to indicate if clear DBUS IPC is invoked
     pthread_mutex_t mutex;            // mutex for the condition var

--- a/include/data_template.h
+++ b/include/data_template.h
@@ -15,7 +15,7 @@
 #ifndef DATA_TEMPLATE_H
 #define DATA_TEMPLATE_H
 
-#include "common.h"  /* for enum save_input_kind */
+#include "common.h"  /* for enum save_mode_op_type */
 
 /**
  * This struct instructs the receiving end how to parse the conntrack
@@ -30,21 +30,21 @@ struct data_template {
 };
 
 /**
- * Allocates a wire-format data_template sized to @kind.
+ * Allocates a wire-format data_template sized to @op_type.
  *
- * SAVE_INPUT_IPS         -> num_bits = CT_ATTR_LEGACY_NUM_BITS (21).
- *                           Byte-identical to what a v1.0 SAVE binary
- *                           emits, so a v1.0 LOAD receiver remains a
- *                           valid migration target.
- * SAVE_INPUT_PORT_ZONES  -> num_bits = CT_ATTR_MAX. Includes the
- *                           appended NAT'd-reply slots that only
- *                           zone-mode payloads ever set.
+ * SAVE_IPS_OP        -> num_bits = CT_ATTR_LEGACY_NUM_BITS (21).
+ *                       Byte-identical to what a v1.0 SAVE binary
+ *                       emits, so a v1.0 LOAD receiver remains a
+ *                       valid migration target.
+ * SAVE_PORT_ZONE_OP  -> num_bits = CT_ATTR_MAX. Includes the
+ *                       appended NAT'd-reply slots that only
+ *                       zone-mode payloads ever set.
  *
  * Caller owns the returned pointer and must free with
  * data_template_destroy().
  */
 struct data_template *
-data_template_new(enum save_input_kind kind);
+data_template_new(enum save_mode_op_type op_type);
 
 void
 data_template_destroy(struct data_template *);

--- a/include/data_template.h
+++ b/include/data_template.h
@@ -15,6 +15,8 @@
 #ifndef DATA_TEMPLATE_H
 #define DATA_TEMPLATE_H
 
+#include "common.h"  /* for enum save_input_kind */
+
 /**
  * This struct instructs the receiving end how to parse the conntrack
  * entries received. num_bits field instructs how many attributes are
@@ -27,8 +29,22 @@ struct data_template {
     uint32_t payload_size; // size of payload array
 };
 
+/**
+ * Allocates a wire-format data_template sized to @kind.
+ *
+ * SAVE_INPUT_IPS         -> num_bits = CT_ATTR_LEGACY_NUM_BITS (21).
+ *                           Byte-identical to what a v1.0 SAVE binary
+ *                           emits, so a v1.0 LOAD receiver remains a
+ *                           valid migration target.
+ * SAVE_INPUT_PORT_ZONES  -> num_bits = CT_ATTR_MAX. Includes the
+ *                           appended NAT'd-reply slots that only
+ *                           zone-mode payloads ever set.
+ *
+ * Caller owns the returned pointer and must free with
+ * data_template_destroy().
+ */
 struct data_template *
-data_template_new(void);
+data_template_new(enum save_input_kind kind);
 
 void
 data_template_destroy(struct data_template *);

--- a/include/dbus_server.h
+++ b/include/dbus_server.h
@@ -47,6 +47,10 @@ struct dbus_targs {
     const char *helper_id;   // helper_id used to export the object
     bool *stop_flag;         // flag to stop the thread listening for events
     enum op_mode mode;       // mode of operation LOAD/SAVE
+    enum save_input_kind save_kind; // SAVE-only; consumed by on_save to
+                                    // size the outgoing data_template.
+                                    // Undefined in LOAD mode (on_save
+                                    // never fires there).
     struct load_mode_config *load_config; // LOAD-only mode config. NULL in SAVE.
 
     /* Loop shutdown coordination. See dbus_server_request_quit. */

--- a/include/dbus_server.h
+++ b/include/dbus_server.h
@@ -39,6 +39,7 @@ struct dbus_targs {
     const char *helper_id;   // helper_id used to export the object
     bool *stop_flag;         // flag to stop the thread listening for events
     enum op_mode mode;       // mode of operation LOAD/SAVE
+    struct load_targets *load_targets; // LOAD-only policy bundle. NULL in SAVE.
 };
 
 void *

--- a/include/dbus_server.h
+++ b/include/dbus_server.h
@@ -47,7 +47,7 @@ struct dbus_targs {
     const char *helper_id;   // helper_id used to export the object
     bool *stop_flag;         // flag to stop the thread listening for events
     enum op_mode mode;       // mode of operation LOAD/SAVE
-    struct load_targets *load_targets; // LOAD-only policy bundle. NULL in SAVE.
+    struct load_mode_config *load_config; // LOAD-only mode config. NULL in SAVE.
 
     /* Loop shutdown coordination. See dbus_server_request_quit. */
     pthread_mutex_t loop_mu;

--- a/include/dbus_server.h
+++ b/include/dbus_server.h
@@ -47,10 +47,10 @@ struct dbus_targs {
     const char *helper_id;   // helper_id used to export the object
     bool *stop_flag;         // flag to stop the thread listening for events
     enum op_mode mode;       // mode of operation LOAD/SAVE
-    enum save_input_kind save_kind; // SAVE-only; consumed by on_save to
-                                    // size the outgoing data_template.
-                                    // Undefined in LOAD mode (on_save
-                                    // never fires there).
+    enum save_mode_op_type save_op_type; // SAVE-only; consumed by on_save
+                                         // to size the outgoing data_template.
+                                         // Undefined in LOAD mode (on_save
+                                         // never fires there).
     struct load_mode_config *load_config; // LOAD-only mode config. NULL in SAVE.
 
     /* Loop shutdown coordination. See dbus_server_request_quit. */

--- a/include/dbus_server.h
+++ b/include/dbus_server.h
@@ -33,6 +33,14 @@ enum op_mode {
 
 /**
  * Represents the arguments to be passed to the dbus_server thread.
+ *
+ * The loop_mu / loop / should_quit fields are used by
+ * dbus_server_request_quit() to ask the dbus thread to exit its main
+ * loop from another thread (typically dmain's error-cleanup path).
+ * The mutex makes the quit signal race-free against
+ * dbus_server_init() still being on its way to g_main_loop_new().
+ * Callers MUST pthread_mutex_init(&loop_mu, NULL) before pthread_create
+ * and pthread_mutex_destroy() after pthread_join.
  */
 struct dbus_targs {
     pthread_t tid;           // represents the thread id
@@ -40,9 +48,28 @@ struct dbus_targs {
     bool *stop_flag;         // flag to stop the thread listening for events
     enum op_mode mode;       // mode of operation LOAD/SAVE
     struct load_targets *load_targets; // LOAD-only policy bundle. NULL in SAVE.
+
+    /* Loop shutdown coordination. See dbus_server_request_quit. */
+    pthread_mutex_t loop_mu;
+    GMainLoop *loop;         // NULL until dbus_server_init creates it
+    bool should_quit;        // set by dbus_server_request_quit
 };
 
 void *
 dbus_server_init(void *);
+
+/**
+ * Asks the dbus thread to exit its main loop gracefully.
+ *
+ * Safe to call from any thread, and safe to call before
+ * dbus_server_init has finished creating the loop: a pre-loop quit
+ * request is latched on should_quit and honoured the moment init
+ * publishes the loop, so the thread exits without ever entering
+ * g_main_loop_run.
+ *
+ * No-op on NULL @targs.
+ */
+void
+dbus_server_request_quit(struct dbus_targs *targs);
 
 #endif /* DBUS_SERVER_H */

--- a/src/common.c
+++ b/src/common.c
@@ -349,8 +349,7 @@ load_targets_new_ips(void)
  *   case any partially-built remap is torn down).
  */
 struct load_targets *
-load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx,
-                                int stride)
+load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx, int stride)
 {
     struct load_targets *targets;
     GHashTable *remap;

--- a/src/common.c
+++ b/src/common.c
@@ -411,11 +411,19 @@ save_targets_destroy(struct save_targets *targets)
         return;
     }
 
-    if (targets->ips_to_migrate != NULL) {
-        g_hash_table_destroy(targets->ips_to_migrate);
-    }
-    if (targets->zones_to_migrate != NULL) {
-        g_hash_table_destroy(targets->zones_to_migrate);
+    /* The two pointers overlay the same memory now, so checking both
+     * blindly would double-free the active arm. Dispatch on @kind. */
+    switch (targets->kind) {
+    case SAVE_INPUT_IPS:
+        if (targets->ips_to_migrate != NULL) {
+            g_hash_table_destroy(targets->ips_to_migrate);
+        }
+        break;
+    case SAVE_INPUT_PORT_ZONES:
+        if (targets->zones_to_migrate != NULL) {
+            g_hash_table_destroy(targets->zones_to_migrate);
+        }
+        break;
     }
 
     g_free(targets);

--- a/src/common.c
+++ b/src/common.c
@@ -32,6 +32,21 @@
 #define PORT_UUID_PREFIX_LEN (sizeof(PORT_UUID_PREFIX) - 1)
 
 /**
+ * Returns a human-readable name for a SAVE sub-mode.
+ *
+ * See declaration in common.h for full doc.
+ */
+const char *
+save_input_kind_to_string(enum save_input_kind kind)
+{
+    switch (kind) {
+    case SAVE_INPUT_IPS:        return "IPS";
+    case SAVE_INPUT_PORT_ZONES: return "PORT_ZONES";
+    }
+    return "UNKNOWN";
+}
+
+/**
  * Creates hashtable from IP addresses list.
  *
  * This function allocates a hashtable which converts the string
@@ -244,6 +259,48 @@ create_hashtable_from_zone_and_port_list(const char *zones[],
 
     *out_ports = ports_ht;
     return zones_ht;
+}
+
+/**
+ * Builds a uint16-keyed hashtable from a strv of decimal zone strings.
+ *
+ * See declaration in common.h for full doc. Caller owns the returned
+ * table. Keys are inlined pointer values (no destroyers attached);
+ * value slots are unused (kept as 1) to mirror create_hashtable_from_ip_list.
+ *
+ * Args:
+ *   @zones       strv of decimal zone strings (e.g. {"100", "200"}).
+ *                Elements at indexes < num_entries must be non-NULL.
+ *   @num_entries number of zones in @zones.
+ *
+ * Returns:
+ *   newly-allocated GHashTable on success; NULL on parse error (any
+ *   partially-built table is torn down before return).
+ */
+GHashTable *
+create_hashtable_from_zone_str_list(const char *zones[], int num_entries)
+{
+    GHashTable *ht;
+    int i;
+
+    ht = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    for (i = 0; i < num_entries; i++) {
+        uint16_t zone;
+
+        if (!parse_ct_zone(zones[i], &zone)) {
+            LOG(ERROR, "%s: invalid zone string at index %d: '%s'",
+                __func__, i, zones[i] ? zones[i] : "(null)");
+            g_hash_table_destroy(ht);
+            return NULL;
+        }
+        g_hash_table_insert(ht, GUINT_TO_POINTER((guint) zone),
+                            GINT_TO_POINTER(1));
+    }
+
+    LOG(INFO, "%s: Built zones_on_host hashtable: %d unique zones",
+        __func__, g_hash_table_size(ht));
+    return ht;
 }
 
 /**

--- a/src/common.c
+++ b/src/common.c
@@ -38,11 +38,11 @@
  * See declaration in common.h for full doc.
  */
 const char *
-save_input_kind_to_string(enum save_input_kind kind)
+convert_save_mode_op_type_to_string(enum save_mode_op_type op_type)
 {
-    switch (kind) {
-    case SAVE_INPUT_IPS:        return "IPS";
-    case SAVE_INPUT_PORT_ZONES: return "PORT_ZONES";
+    switch (op_type) {
+    case SAVE_IPS_OP:        return "IPS";
+    case SAVE_PORT_ZONE_OP:  return "PORT_ZONE";
     }
     return "UNKNOWN";
 }
@@ -380,7 +380,7 @@ create_save_mode_config_for_ip_mode(GHashTable *ips_to_migrate)
     }
 
     save_config = g_malloc0(sizeof(*save_config));
-    save_config->kind = SAVE_INPUT_IPS;
+    save_config->op_type = SAVE_IPS_OP;
     save_config->ips_to_migrate = ips_to_migrate;
     return save_config;
 }
@@ -409,7 +409,7 @@ create_save_mode_config_for_port_zone_mode(GHashTable *zones)
     }
 
     zone_based_save_config = g_malloc0(sizeof(*zone_based_save_config));
-    zone_based_save_config->kind = SAVE_INPUT_PORT_ZONES;
+    zone_based_save_config->op_type = SAVE_PORT_ZONE_OP;
     zone_based_save_config->zones_to_migrate = zones;
     return zone_based_save_config;
 }
@@ -430,15 +430,15 @@ destroy_save_mode_config(struct save_mode_config *save_config)
     }
 
     /* The two pointers overlay the same memory now, so checking both
-     * blindly would double-free the active arm. Dispatch on @kind. */
-    switch (save_config->kind) {
-    case SAVE_INPUT_IPS:
+     * blindly would double-free the active arm. Dispatch on @op_type. */
+    switch (save_config->op_type) {
+    case SAVE_IPS_OP:
         if (save_config->ips_to_migrate != NULL) {
             g_hash_table_destroy(save_config->ips_to_migrate);
             save_config->ips_to_migrate = NULL;
         }
         break;
-    case SAVE_INPUT_PORT_ZONES:
+    case SAVE_PORT_ZONE_OP:
         if (save_config->zones_to_migrate != NULL) {
             g_hash_table_destroy(save_config->zones_to_migrate);
             save_config->zones_to_migrate = NULL;
@@ -454,7 +454,7 @@ destroy_save_mode_config(struct save_mode_config *save_config)
  *
  * Legacy LOAD carries no zone information on the wire and needs no
  * rewrite, so src_dst_zone_map is left NULL. apply_zone_rewrite() in
- * dbus_server.c short-circuits when kind is LOAD_INPUT_LEGACY.
+ * dbus_server.c short-circuits when op_type is LOAD_IPS_OP.
  *
  * Returns:
  *   pointer to the bundle. Process aborts on allocation failure.
@@ -465,7 +465,7 @@ create_load_mode_config_for_legacy_mode(void)
     struct load_mode_config *load_config;
 
     load_config = g_malloc0(sizeof(*load_config));
-    load_config->kind = LOAD_INPUT_LEGACY;
+    load_config->op_type = LOAD_IPS_OP;
     return load_config;
 }
 
@@ -500,7 +500,7 @@ create_load_mode_config_for_port_zone_mode(GHashTable *src_dst_zone_map)
     }
 
     zone_based_load_config = g_malloc0(sizeof(*zone_based_load_config));
-    zone_based_load_config->kind = LOAD_INPUT_PORT_ZONES;
+    zone_based_load_config->op_type = LOAD_PORT_ZONE_OP;
     zone_based_load_config->src_dst_zone_map = src_dst_zone_map;
     return zone_based_load_config;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -20,11 +20,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <uuid/uuid.h>
+
 #include "common.h"
 #include "log.h"
-
-/* Canonical UUID body length: 8-4-4-4-12 = 36 chars. */
-#define UUID_STRING_LEN 36
 
 /* Required literal prefix for the port-UUID wire form.
  * Full accepted shape is: "port_" + <canonical 8-4-4-4-12 UUID>, total 41
@@ -117,12 +116,11 @@ create_hashtable_from_ip_list(const char *ip_list[], int num_ips)
  * Validates that @s is a port-prefixed UUID string of the form
  * "port_<canonical 8-4-4-4-12 hex UUID>" (total length 41).
  *
- * The "port_" prefix is the wire form supplied by libvirt and is part of
- * the value; this validator rejects bare UUIDs without the prefix. The
- * UUID body is checked structurally only - dashes at offsets 8/13/18/23
- * and hex (case-insensitive) everywhere else. No version/variant bit
- * checks: callers pass canonical UUIDs and we only need to reject
- * obvious junk.
+ * The "port_" prefix is the wire form supplied by libvirt and is part
+ * of the value; this validator rejects bare UUIDs without the prefix.
+ * The UUID body itself is parsed by libuuid's uuid_parse(), which
+ * enforces canonical 8-4-4-4-12 hex form (case-insensitive) - the
+ * de-facto standard parser on the platform.
  *
  * Args:
  *   @s nul-terminated candidate string. May be NULL.
@@ -133,7 +131,7 @@ create_hashtable_from_ip_list(const char *ip_list[], int num_ips)
 bool
 is_valid_uuid_string(const char *s)
 {
-    int i;
+    uuid_t parsed;
 
     if (s == NULL) {
         return false;
@@ -141,29 +139,7 @@ is_valid_uuid_string(const char *s)
     if (strncmp(s, PORT_UUID_PREFIX, PORT_UUID_PREFIX_LEN) != 0) {
         return false;
     }
-    s += PORT_UUID_PREFIX_LEN;
-
-    if (strlen(s) != UUID_STRING_LEN) {
-        return false;
-    }
-
-    for (i = 0; i < UUID_STRING_LEN; i++) {
-        char c = s[i];
-
-        if (i == 8 || i == 13 || i == 18 || i == 23) {
-            if (c != '-') {
-                return false;
-            }
-        } else {
-            bool is_hex = (c >= '0' && c <= '9') ||
-                          (c >= 'a' && c <= 'f') ||
-                          (c >= 'A' && c <= 'F');
-            if (!is_hex) {
-                return false;
-            }
-        }
-    }
-    return true;
+    return uuid_parse(s + PORT_UUID_PREFIX_LEN, parsed) == 0;
 }
 
 /**

--- a/src/common.c
+++ b/src/common.c
@@ -228,75 +228,46 @@ ensure_cli_arg_is_int_at_least(const char *arg_value, int *out_value,
 }
 
 /**
- * Builds the (zones_to_migrate, ports_to_migrate) hashtable pair from
- * parallel parsed-CLI arrays.
+ * Builds the zones_to_migrate hashtable from a parsed-CLI zone array.
  *
  * Inputs are already arity- and content-validated by check_zone_save_args
- * (in main.c) before this is called, so a parse failure here is treated as
- * a defensive bug-in-caller and both tables are torn down.
+ * (in main.c) before this is called, so a parse failure here is treated
+ * as a defensive bug-in-caller and the partial table is torn down.
  *
- * Ownership: both returned tables are caller-owned. The "zones" table is
- * the function return value; the "ports" table is returned via @out_ports.
- * Keys/values are copied (g_strdup / g_memdup) so the argv slices the
- * caller passed do not need to outlive the tables.
+ * Ownership: the returned table is caller-owned. Keys are inlined zone
+ * values (no destroyers attached); value slots are unused (kept as 1)
+ * to mirror create_hashtable_from_ip_list.
  *
  * Args:
- *   @zones      array of nul-terminated decimal zone strings (length n)
- *   @port_uuids array of nul-terminated UUID strings (length n)
- *   @n_entries  number of (zone, port_uuid) pairs
- *   @out_ports  output: ports_to_migrate hashtable (port_uuid -> uint16 zone)
+ *   @zones     array of nul-terminated decimal zone strings (length n)
+ *   @n_entries number of zone strings to consume
  *
  * Returns:
- *   zones_to_migrate hashtable on success, NULL on failure (in which case
- *   *out_ports is left set to NULL).
+ *   zones_to_migrate hashtable on success, NULL on failure.
  */
 GHashTable *
-create_hashtable_from_zone_and_port_list(const char *zones[],
-                                         const char *port_uuids[],
-                                         int n_entries,
-                                         GHashTable **out_ports)
+create_hashtable_from_zone_list(const char *zones[], int n_entries)
 {
     int i;
     GHashTable *zones_ht;
-    GHashTable *ports_ht;
-
-    if (out_ports == NULL) {
-        return NULL;
-    }
-    *out_ports = NULL;
 
     zones_ht = g_hash_table_new(g_direct_hash, g_direct_equal);
-    ports_ht = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
     for (i = 0; i < n_entries; i++) {
         uint16_t zone;
-        uint16_t *zone_val;
 
         if (!parse_ct_zone(zones[i], &zone)) {
             LOG(ERROR, "%s: Invalid zone at index %d: '%s'", __func__,
                 i, zones[i]);
             g_hash_table_destroy(zones_ht);
-            g_hash_table_destroy(ports_ht);
-            return NULL;
-        }
-        if (!is_valid_uuid_string(port_uuids[i])) {
-            LOG(ERROR, "%s: Invalid port UUID at index %d: '%s'", __func__,
-                i, port_uuids[i]);
-            g_hash_table_destroy(zones_ht);
-            g_hash_table_destroy(ports_ht);
             return NULL;
         }
 
         g_hash_table_insert(zones_ht,
                             GUINT_TO_POINTER((guint) zone),
                             GINT_TO_POINTER(1));
-
-        zone_val = g_malloc(sizeof(*zone_val));
-        *zone_val = zone;
-        g_hash_table_insert(ports_ht, g_strdup(port_uuids[i]), zone_val);
     }
 
-    *out_ports = ports_ht;
     return zones_ht;
 }
 
@@ -403,27 +374,25 @@ save_targets_new_from_ips(GHashTable *ips_to_migrate)
 }
 
 /**
- * Allocates a save_targets bundle wrapping a (zones, ports) pair.
+ * Allocates a save_targets bundle wrapping a zones_to_migrate hashtable.
  *
- * Takes ownership of both hashtables; subsequent save_targets_destroy()
- * will destroy them.
+ * Takes ownership of @zones; subsequent save_targets_destroy() will
+ * destroy it.
  *
  * Args:
  *   @zones zones_to_migrate hashtable. Must be non-NULL.
- *   @ports ports_to_migrate hashtable. Must be non-NULL.
  *
  * Returns:
  *   pointer to the bundle. Process aborts on allocation failure.
  */
 struct save_targets *
-save_targets_new_from_zones_and_ports(GHashTable *zones, GHashTable *ports)
+save_targets_new_from_zones(GHashTable *zones)
 {
     struct save_targets *targets;
 
     targets = g_malloc0(sizeof(*targets));
     targets->kind = SAVE_INPUT_PORT_ZONES;
     targets->zones_to_migrate = zones;
-    targets->ports_to_migrate = ports;
     return targets;
 }
 
@@ -447,9 +416,6 @@ save_targets_destroy(struct save_targets *targets)
     }
     if (targets->zones_to_migrate != NULL) {
         g_hash_table_destroy(targets->zones_to_migrate);
-    }
-    if (targets->ports_to_migrate != NULL) {
-        g_hash_table_destroy(targets->ports_to_migrate);
     }
 
     g_free(targets);

--- a/src/common.c
+++ b/src/common.c
@@ -12,7 +12,9 @@
  */
 
 #include <arpa/inet.h> // For struct in_addr.
+#include <err.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -186,6 +188,43 @@ parse_ct_zone(const char *s, uint16_t *out)
 
     *out = (uint16_t) v;
     return true;
+}
+
+/**
+ * Ensures a CLI argument is an integer >= @min_value.
+ *
+ * See declaration in common.h for the full contract.
+ */
+void
+ensure_cli_arg_is_int_at_least(const char *arg_value, int *out_value,
+                               const char *arg_name, int min_value)
+{
+    char *end;
+    long v;
+
+    if (arg_value == NULL || *arg_value == '\0') {
+        errx(EXIT_FAILURE, "Missing value for '%s'", arg_name);
+    }
+
+    /* Base 10: lock the grammar to decimal so "010" is ten, not octal
+     * eight (which strtol would do with base 0). Value range is
+     * checked separately below; the base only affects how digits are
+     * read, not how big the result can be. */
+    errno = 0;
+    v = strtol(arg_value, &end, 10);
+
+    if (errno != 0 || end == arg_value || *end != '\0') {
+        errx(EXIT_FAILURE,
+             "Invalid value for '%s': '%s' (must be a valid integer)",
+             arg_name, arg_value);
+    }
+    if (v < (long) min_value || v > INT_MAX) {
+        errx(EXIT_FAILURE,
+             "Invalid value for '%s': '%s' (must be in range [%d, %d])",
+             arg_name, arg_value, min_value, INT_MAX);
+    }
+
+    *out_value = (int) v;
 }
 
 /**

--- a/src/common.c
+++ b/src/common.c
@@ -70,7 +70,7 @@ save_input_kind_to_string(enum save_input_kind kind)
  *   NULL, in case an invalid IP address is present in the ip_list.
  */
 GHashTable *
-create_hashtable_from_ip_list(const char *ip_list[], int num_ips)
+create_hashtable_from_ip_list(const char *const ip_list[], int num_ips)
 {
     int i;
     GHashTable *ht;
@@ -232,7 +232,7 @@ ensure_cli_arg_is_int_at_least(const char *arg_value, int *out_value,
  *   zones_to_migrate hashtable on success, NULL on failure.
  */
 GHashTable *
-create_hashtable_from_zone_list(const char *zones[], int n_entries)
+create_hashtable_from_zone_list(const char *const zones[], int n_entries)
 {
     int i;
     GHashTable *zones_ht;

--- a/src/common.c
+++ b/src/common.c
@@ -262,45 +262,82 @@ create_hashtable_from_zone_and_port_list(const char *zones[],
 }
 
 /**
- * Builds a uint16-keyed hashtable from a strv of decimal zone strings.
+ * Builds a uint16-keyed hashtable from a strv of paired
+ * [port_uuid_0, zone_0, port_uuid_1, zone_1, ...] elements.
  *
- * See declaration in common.h for full doc. Caller owns the returned
- * table. Keys are inlined pointer values (no destroyers attached);
- * value slots are unused (kept as 1) to mirror create_hashtable_from_ip_list.
+ * See declaration in common.h for the full contract. Caller owns the
+ * returned table. Keys are inlined pointer values (no destroyers
+ * attached); value slots are unused (kept as 1) to mirror
+ * create_hashtable_from_ip_list.
+ *
+ * The port_uuid half of each pair is parsed for well-formedness so a
+ * garbled payload is rejected up front, but is otherwise discarded:
+ * the zone-mode delete path only filters on CT zone.
  *
  * Args:
- *   @zones       strv of decimal zone strings (e.g. {"100", "200"}).
- *                Elements at indexes < num_entries must be non-NULL.
- *   @num_entries number of zones in @zones.
+ *   @port_zone_strv flat strv of alternating port_uuid / decimal-zone
+ *                   strings: [port_uuid_0, zone_0, port_uuid_1, zone_1,
+ *                   ...]. Length must be 2 * num_pairs and elements at
+ *                   indexes < num_entries must be non-NULL.
+ *   @num_entries    total number of strv elements (must be even). The
+ *                   pair count is num_entries / 2.
  *
  * Returns:
  *   newly-allocated GHashTable on success; NULL on parse error (any
  *   partially-built table is torn down before return).
  */
 GHashTable *
-create_hashtable_from_zone_str_list(const char *zones[], int num_entries)
+create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
+                                      int num_entries)
 {
-    GHashTable *ht;
-    int i;
+    GHashTable *zones_on_host;
+    int num_pairs;
+    int pair_idx;
 
-    ht = g_hash_table_new(g_direct_hash, g_direct_equal);
+    if (num_entries % 2 != 0) {
+        LOG(ERROR, "%s: expected even-length strv (port_uuid, zone) pairs, "
+            "got %d entries", __func__, num_entries);
+        return NULL;
+    }
+    num_pairs = num_entries / 2;
 
-    for (i = 0; i < num_entries; i++) {
+    zones_on_host = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    for (pair_idx = 0; pair_idx < num_pairs; pair_idx++) {
+        const int port_uuid_slot = pair_idx * 2;
+        const int zone_slot      = port_uuid_slot + 1;
+        const char *port_uuid    = port_zone_strv[port_uuid_slot];
+        const char *zone_str     = port_zone_strv[zone_slot];
         uint16_t zone;
 
-        if (!parse_ct_zone(zones[i], &zone)) {
-            LOG(ERROR, "%s: invalid zone string at index %d: '%s'",
-                __func__, i, zones[i] ? zones[i] : "(null)");
-            g_hash_table_destroy(ht);
+        if (port_uuid == NULL || zone_str == NULL) {
+            LOG(ERROR, "%s: NULL element at pair index %d",
+                __func__, pair_idx);
+            g_hash_table_destroy(zones_on_host);
             return NULL;
         }
-        g_hash_table_insert(ht, GUINT_TO_POINTER((guint) zone),
+        if (!is_valid_uuid_string(port_uuid)) {
+            LOG(ERROR, "%s: malformed port UUID at pair index %d: '%s'",
+                __func__, pair_idx, port_uuid);
+            g_hash_table_destroy(zones_on_host);
+            return NULL;
+        }
+        if (!parse_ct_zone(zone_str, &zone)) {
+            LOG(ERROR, "%s: invalid zone for port %s at pair index %d: '%s'",
+                __func__, port_uuid, pair_idx, zone_str);
+            g_hash_table_destroy(zones_on_host);
+            return NULL;
+        }
+
+        g_hash_table_insert(zones_on_host,
+                            GUINT_TO_POINTER((guint) zone),
                             GINT_TO_POINTER(1));
     }
 
-    LOG(INFO, "%s: Built zones_on_host hashtable: %d unique zones",
-        __func__, g_hash_table_size(ht));
-    return ht;
+    LOG(INFO, "%s: Built zones_on_host hashtable: %d unique zones (from "
+        "%d port/zone pairs)",
+        __func__, g_hash_table_size(zones_on_host), num_pairs);
+    return zones_on_host;
 }
 
 /**

--- a/src/common.c
+++ b/src/common.c
@@ -474,13 +474,14 @@ load_targets_new_ips(void)
  * (old_zone -> new_zone) remap hashtable.
  *
  * Mirrors save_targets_new_from_zones() on the SAVE side: argv walking
- * lives in main.c (build_zone_remap_from_args), and this function is a
- * pure wrapper that takes ownership of the remap.
+ * lives in main.c (check_zone_load_args, which validates and builds the
+ * remap in one pass during pre-fork CLI checking), and this function is
+ * a pure wrapper that takes ownership of the remap.
  *
  * Args:
- *   @remap  hashtable built by build_zone_remap_from_args(). Must be
- *           non-NULL. Ownership transfers to the returned bundle and
- *           is released by load_targets_destroy().
+ *   @remap  hashtable built by check_zone_load_args(). Must be non-NULL.
+ *           Ownership transfers to the returned bundle and is released
+ *           by load_targets_destroy().
  *
  * Returns:
  *   pointer to the bundle. Process aborts on a NULL @remap (caller

--- a/src/common.c
+++ b/src/common.c
@@ -76,6 +76,16 @@ create_hashtable_from_ip_list(const char *ip_list[], int num_ips)
     int i;
     GHashTable *ht;
 
+    if (num_ips < 0) {
+        LOG(ERROR, "%s: negative num_ips (%d)", __func__, num_ips);
+        return NULL;
+    }
+    if (num_ips > 0 && ip_list == NULL) {
+        LOG(ERROR, "%s: num_ips=%d but ip_list is NULL",
+            __func__, num_ips);
+        return NULL;
+    }
+
     ht = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
 
     for (i = 0; i < num_ips; i++) {
@@ -251,6 +261,16 @@ create_hashtable_from_zone_list(const char *zones[], int n_entries)
     int i;
     GHashTable *zones_ht;
 
+    if (n_entries < 0) {
+        LOG(ERROR, "%s: negative n_entries (%d)", __func__, n_entries);
+        return NULL;
+    }
+    if (n_entries > 0 && zones == NULL) {
+        LOG(ERROR, "%s: n_entries=%d but zones is NULL",
+            __func__, n_entries);
+        return NULL;
+    }
+
     zones_ht = g_hash_table_new(g_direct_hash, g_direct_equal);
 
     for (i = 0; i < n_entries; i++) {
@@ -303,6 +323,16 @@ create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
     GHashTable *zones_on_host;
     int num_pairs;
     int pair_idx;
+
+    if (num_entries < 0) {
+        LOG(ERROR, "%s: negative num_entries (%d)", __func__, num_entries);
+        return NULL;
+    }
+    if (num_entries > 0 && port_zone_strv == NULL) {
+        LOG(ERROR, "%s: num_entries=%d but port_zone_strv is NULL",
+            __func__, num_entries);
+        return NULL;
+    }
 
     if (num_entries % 2 != 0) {
         LOG(ERROR, "%s: expected even-length strv (port_uuid, zone) pairs, "
@@ -367,6 +397,12 @@ save_targets_new_from_ips(GHashTable *ips_to_migrate)
 {
     struct save_targets *targets;
 
+    if (ips_to_migrate == NULL) {
+        errx(EXIT_FAILURE,
+             "%s: refusing to allocate IP-mode save_targets with NULL "
+             "ips_to_migrate (programmer error in caller)", __func__);
+    }
+
     targets = g_malloc0(sizeof(*targets));
     targets->kind = SAVE_INPUT_IPS;
     targets->ips_to_migrate = ips_to_migrate;
@@ -389,6 +425,12 @@ struct save_targets *
 save_targets_new_from_zones(GHashTable *zones)
 {
     struct save_targets *targets;
+
+    if (zones == NULL) {
+        errx(EXIT_FAILURE,
+             "%s: refusing to allocate zone-mode save_targets with NULL "
+             "zones (programmer error in caller)", __func__);
+    }
 
     targets = g_malloc0(sizeof(*targets));
     targets->kind = SAVE_INPUT_PORT_ZONES;
@@ -417,11 +459,13 @@ save_targets_destroy(struct save_targets *targets)
     case SAVE_INPUT_IPS:
         if (targets->ips_to_migrate != NULL) {
             g_hash_table_destroy(targets->ips_to_migrate);
+            targets->ips_to_migrate = NULL;
         }
         break;
     case SAVE_INPUT_PORT_ZONES:
         if (targets->zones_to_migrate != NULL) {
             g_hash_table_destroy(targets->zones_to_migrate);
+            targets->zones_to_migrate = NULL;
         }
         break;
     }
@@ -446,7 +490,6 @@ load_targets_new_ips(void)
 
     targets = g_malloc0(sizeof(*targets));
     targets->kind       = LOAD_INPUT_LEGACY;
-    targets->zone_remap = NULL;
     return targets;
 }
 
@@ -480,6 +523,24 @@ load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx, int 
     struct load_targets *targets;
     GHashTable *remap;
     int i;
+
+    if (n_entries < 0) {
+        LOG(ERROR, "%s: negative n_entries (%d)", __func__, n_entries);
+        return NULL;
+    }
+    if (n_entries > 0 && argv == NULL) {
+        LOG(ERROR, "%s: n_entries=%d but argv is NULL",
+            __func__, n_entries);
+        return NULL;
+    }
+    if (start_idx < 0) {
+        LOG(ERROR, "%s: negative start_idx (%d)", __func__, start_idx);
+        return NULL;
+    }
+    if (stride <= 0) {
+        LOG(ERROR, "%s: non-positive stride (%d)", __func__, stride);
+        return NULL;
+    }
 
     remap = g_hash_table_new(g_direct_hash, g_direct_equal);
 
@@ -538,6 +599,7 @@ load_targets_destroy(struct load_targets *targets)
     }
     if (targets->zone_remap != NULL) {
         g_hash_table_destroy(targets->zone_remap);
+        targets->zone_remap = NULL;
     }
     g_free(targets);
 }

--- a/src/common.c
+++ b/src/common.c
@@ -12,10 +12,17 @@
  */
 
 #include <arpa/inet.h> // For struct in_addr.
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "common.h"
 #include "log.h"
+
+/* Canonical UUID hex string length: 8-4-4-4-12 = 36 chars. */
+#define UUID_STRING_LEN 36
 
 /**
  * Creates hashtable from IP addresses list.
@@ -70,4 +77,228 @@ create_hashtable_from_ip_list(const char *ip_list[], int num_ips)
     }
 
     return ht;
+}
+
+/**
+ * Validates that @s is a canonical 8-4-4-4-12 hex UUID string.
+ *
+ * No version/variant bit checks - any 36-char hex-with-hyphens string
+ * is accepted. This is intentionally permissive: callers (e.g. libvirt)
+ * pass UUIDs in canonical form and we only need to reject obvious junk.
+ *
+ * Args:
+ *   @s nul-terminated candidate string. May be NULL.
+ *
+ * Returns:
+ *   true if the string is well-formed, false otherwise.
+ */
+bool
+is_valid_uuid_string(const char *s)
+{
+    int i;
+
+    if (s == NULL || strlen(s) != UUID_STRING_LEN) {
+        return false;
+    }
+
+    for (i = 0; i < UUID_STRING_LEN; i++) {
+        char c = s[i];
+
+        if (i == 8 || i == 13 || i == 18 || i == 23) {
+            if (c != '-') {
+                return false;
+            }
+        } else {
+            bool is_hex = (c >= '0' && c <= '9') ||
+                          (c >= 'a' && c <= 'f') ||
+                          (c >= 'A' && c <= 'F');
+            if (!is_hex) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Strict parser for a CT zone: must be a complete decimal uint16 with no
+ * trailing junk, no whitespace, no overflow.
+ *
+ * Uses the standard out-parameter pattern: @out is only written on success.
+ * On failure the caller's storage is left untouched.
+ *
+ * Args:
+ *   @s   nul-terminated decimal string.
+ *   @out output uint16_t (only written on success). Must be non-NULL.
+ *
+ * Returns:
+ *   true on success, false otherwise.
+ */
+bool
+parse_ct_zone(const char *s, uint16_t *out)
+{
+    char *end = NULL;
+    unsigned long v;
+
+    if (s == NULL || *s == '\0' || out == NULL) {
+        return false;
+    }
+
+    errno = 0;
+    v = strtoul(s, &end, 10);
+    if (errno != 0 || end == s || *end != '\0' || v > UINT16_MAX) {
+        return false;
+    }
+
+    *out = (uint16_t) v;
+    return true;
+}
+
+/**
+ * Builds the (zones_to_migrate, ports_to_migrate) hashtable pair from
+ * parallel parsed-CLI arrays.
+ *
+ * Inputs are already arity- and content-validated by check_zone_save_args
+ * (in main.c) before this is called, so a parse failure here is treated as
+ * a defensive bug-in-caller and both tables are torn down.
+ *
+ * Ownership: both returned tables are caller-owned. The "zones" table is
+ * the function return value; the "ports" table is returned via @out_ports.
+ * Keys/values are copied (g_strdup / g_memdup) so the argv slices the
+ * caller passed do not need to outlive the tables.
+ *
+ * Args:
+ *   @zones      array of nul-terminated decimal zone strings (length n)
+ *   @port_uuids array of nul-terminated UUID strings (length n)
+ *   @n_entries  number of (zone, port_uuid) pairs
+ *   @out_ports  output: ports_to_migrate hashtable (port_uuid -> uint16 zone)
+ *
+ * Returns:
+ *   zones_to_migrate hashtable on success, NULL on failure (in which case
+ *   *out_ports is left set to NULL).
+ */
+GHashTable *
+create_hashtable_from_zone_and_port_list(const char *zones[],
+                                         const char *port_uuids[],
+                                         int n_entries,
+                                         GHashTable **out_ports)
+{
+    int i;
+    GHashTable *zones_ht;
+    GHashTable *ports_ht;
+
+    if (out_ports == NULL) {
+        return NULL;
+    }
+    *out_ports = NULL;
+
+    zones_ht = g_hash_table_new(g_direct_hash, g_direct_equal);
+    ports_ht = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+    for (i = 0; i < n_entries; i++) {
+        uint16_t zone;
+        uint16_t *zone_val;
+
+        if (!parse_ct_zone(zones[i], &zone)) {
+            LOG(ERROR, "%s: Invalid zone at index %d: '%s'", __func__,
+                i, zones[i]);
+            g_hash_table_destroy(zones_ht);
+            g_hash_table_destroy(ports_ht);
+            return NULL;
+        }
+        if (!is_valid_uuid_string(port_uuids[i])) {
+            LOG(ERROR, "%s: Invalid port UUID at index %d: '%s'", __func__,
+                i, port_uuids[i]);
+            g_hash_table_destroy(zones_ht);
+            g_hash_table_destroy(ports_ht);
+            return NULL;
+        }
+
+        g_hash_table_insert(zones_ht,
+                            GUINT_TO_POINTER((guint) zone),
+                            GINT_TO_POINTER(1));
+
+        zone_val = g_malloc(sizeof(*zone_val));
+        *zone_val = zone;
+        g_hash_table_insert(ports_ht, g_strdup(port_uuids[i]), zone_val);
+    }
+
+    *out_ports = ports_ht;
+    return zones_ht;
+}
+
+/**
+ * Allocates a save_targets bundle wrapping an ips_to_migrate hashtable.
+ *
+ * Takes ownership of @ips_to_migrate; subsequent save_targets_destroy()
+ * will destroy it.
+ *
+ * Args:
+ *   @ips_to_migrate hashtable of IP addresses to migrate. Must be non-NULL.
+ *
+ * Returns:
+ *   pointer to the bundle. Process aborts on allocation failure.
+ */
+struct save_targets *
+save_targets_new_from_ips(GHashTable *ips_to_migrate)
+{
+    struct save_targets *targets;
+
+    targets = g_malloc0(sizeof(*targets));
+    targets->kind = SAVE_INPUT_IPS;
+    targets->ips_to_migrate = ips_to_migrate;
+    return targets;
+}
+
+/**
+ * Allocates a save_targets bundle wrapping a (zones, ports) pair.
+ *
+ * Takes ownership of both hashtables; subsequent save_targets_destroy()
+ * will destroy them.
+ *
+ * Args:
+ *   @zones zones_to_migrate hashtable. Must be non-NULL.
+ *   @ports ports_to_migrate hashtable. Must be non-NULL.
+ *
+ * Returns:
+ *   pointer to the bundle. Process aborts on allocation failure.
+ */
+struct save_targets *
+save_targets_new_from_zones_and_ports(GHashTable *zones, GHashTable *ports)
+{
+    struct save_targets *targets;
+
+    targets = g_malloc0(sizeof(*targets));
+    targets->kind = SAVE_INPUT_PORT_ZONES;
+    targets->zones_to_migrate = zones;
+    targets->ports_to_migrate = ports;
+    return targets;
+}
+
+/**
+ * Releases a save_targets bundle and the hashtables it owns.
+ *
+ * NULL-tolerant.
+ *
+ * Args:
+ *   @targets pointer to the bundle. May be NULL.
+ */
+void
+save_targets_destroy(struct save_targets *targets)
+{
+    if (targets == NULL) {
+        return;
+    }
+
+    if (targets->ips_to_migrate != NULL) {
+        g_hash_table_destroy(targets->ips_to_migrate);
+    }
+    if (targets->zones_to_migrate != NULL) {
+        g_hash_table_destroy(targets->zones_to_migrate);
+    }
+    if (targets->ports_to_migrate != NULL) {
+        g_hash_table_destroy(targets->ports_to_migrate);
+    }
+
+    g_free(targets);
 }

--- a/src/common.c
+++ b/src/common.c
@@ -494,87 +494,31 @@ load_targets_new_ips(void)
 }
 
 /**
- * Builds the LOAD targets bundle for the new port-zone CLI shape.
+ * Allocates a LOAD targets bundle that wraps a pre-built
+ * (old_zone -> new_zone) remap hashtable.
  *
- * Walks argv at the @stride-strided offsets starting from @start_idx.
- * The port_uuid column at offset 0 is intentionally ignored: at LOAD
- * time the only thing each CT entry carries is ATTR_ZONE, so the only
- * usable pivot is old_zone -> new_zone. UUID well-formedness has
- * already been validated by check_zone_load_args() in main.c.
- *
- * If two entries declare the same old_zone with different new_zones,
- * the last write wins and a WARNING is logged. The CLI validator can
- * be tightened later to reject this shape outright.
+ * Mirrors save_targets_new_from_zones() on the SAVE side: argv walking
+ * lives in main.c (build_zone_remap_from_args), and this function is a
+ * pure wrapper that takes ownership of the remap.
  *
  * Args:
- *   @n_entries  declared N from argv[NUM_ENTRIES_ARG_INDEX].
- *   @argv       full argv array.
- *   @start_idx  index of the first per-entry slot (typically
- *               ENTRIES_LIST_START_ARG_INDEX).
- *   @stride     LOAD_PORT_ZONE_STRIDE.
+ *   @remap  hashtable built by build_zone_remap_from_args(). Must be
+ *           non-NULL. Ownership transfers to the returned bundle and
+ *           is released by load_targets_destroy().
  *
  * Returns:
- *   pointer to the bundle on success, NULL on parse failure (in which
- *   case any partially-built remap is torn down).
+ *   pointer to the bundle. Process aborts on a NULL @remap (caller
+ *   contract violation) or on allocation failure.
  */
 struct load_targets *
-load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx, int stride)
+load_targets_new_from_remap(GHashTable *remap)
 {
     struct load_targets *targets;
-    GHashTable *remap;
-    int i;
 
-    if (n_entries < 0) {
-        LOG(ERROR, "%s: negative n_entries (%d)", __func__, n_entries);
-        return NULL;
-    }
-    if (n_entries > 0 && argv == NULL) {
-        LOG(ERROR, "%s: n_entries=%d but argv is NULL",
-            __func__, n_entries);
-        return NULL;
-    }
-    if (start_idx < 0) {
-        LOG(ERROR, "%s: negative start_idx (%d)", __func__, start_idx);
-        return NULL;
-    }
-    if (stride <= 0) {
-        LOG(ERROR, "%s: non-positive stride (%d)", __func__, stride);
-        return NULL;
-    }
-
-    remap = g_hash_table_new(g_direct_hash, g_direct_equal);
-
-    for (i = 0; i < n_entries; i++) {
-        int base = start_idx + (i * stride);
-        const char *old_str = argv[base + 1];
-        const char *new_str = argv[base + 2];
-        uint16_t old_zone, new_zone;
-
-        if (!parse_ct_zone(old_str, &old_zone) ||
-            !parse_ct_zone(new_str, &new_zone)) {
-            LOG(ERROR, "%s: failed to parse zone at entry %d "
-                "(old='%s' new='%s')",
-                __func__, i, old_str, new_str);
-            g_hash_table_destroy(remap);
-            return NULL;
-        }
-
-        if (g_hash_table_contains(remap,
-                                  GUINT_TO_POINTER((guint) old_zone))) {
-            uint16_t existing = (uint16_t) GPOINTER_TO_UINT(
-                g_hash_table_lookup(remap,
-                    GUINT_TO_POINTER((guint) old_zone)));
-            if (existing != new_zone) {
-                LOG(WARNING, "%s: old_zone %u remapped twice "
-                    "(was -> %u, now -> %u). Last write wins.",
-                    __func__, (unsigned) old_zone,
-                    (unsigned) existing, (unsigned) new_zone);
-            }
-        }
-
-        g_hash_table_insert(remap,
-                            GUINT_TO_POINTER((guint) old_zone),
-                            GUINT_TO_POINTER((guint) new_zone));
+    if (remap == NULL) {
+        errx(EXIT_FAILURE,
+             "%s: refusing to allocate port-zone load_targets with NULL "
+             "remap (programmer error in caller)", __func__);
     }
 
     targets = g_malloc0(sizeof(*targets));

--- a/src/common.c
+++ b/src/common.c
@@ -357,9 +357,9 @@ create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
 }
 
 /**
- * Allocates a save_targets bundle wrapping an ips_to_migrate hashtable.
+ * Allocates a save_mode_config bundle wrapping an ips_to_migrate hashtable.
  *
- * Takes ownership of @ips_to_migrate; subsequent save_targets_destroy()
+ * Takes ownership of @ips_to_migrate; subsequent destroy_save_mode_config()
  * will destroy it.
  *
  * Args:
@@ -368,27 +368,27 @@ create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
  * Returns:
  *   pointer to the bundle. Process aborts on allocation failure.
  */
-struct save_targets *
-save_targets_new_from_ips(GHashTable *ips_to_migrate)
+struct save_mode_config *
+create_save_mode_config_for_ip_mode(GHashTable *ips_to_migrate)
 {
-    struct save_targets *targets;
+    struct save_mode_config *save_config;
 
     if (ips_to_migrate == NULL) {
         errx(EXIT_FAILURE,
-             "%s: refusing to allocate IP-mode save_targets with NULL "
+             "%s: refusing to allocate IP-mode save_mode_config with NULL "
              "ips_to_migrate (programmer error in caller)", __func__);
     }
 
-    targets = g_malloc0(sizeof(*targets));
-    targets->kind = SAVE_INPUT_IPS;
-    targets->ips_to_migrate = ips_to_migrate;
-    return targets;
+    save_config = g_malloc0(sizeof(*save_config));
+    save_config->kind = SAVE_INPUT_IPS;
+    save_config->ips_to_migrate = ips_to_migrate;
+    return save_config;
 }
 
 /**
- * Allocates a save_targets bundle wrapping a zones_to_migrate hashtable.
+ * Allocates a save_mode_config bundle wrapping a zones_to_migrate hashtable.
  *
- * Takes ownership of @zones; subsequent save_targets_destroy() will
+ * Takes ownership of @zones; subsequent destroy_save_mode_config() will
  * destroy it.
  *
  * Args:
@@ -397,130 +397,131 @@ save_targets_new_from_ips(GHashTable *ips_to_migrate)
  * Returns:
  *   pointer to the bundle. Process aborts on allocation failure.
  */
-struct save_targets *
-save_targets_new_from_zones(GHashTable *zones)
+struct save_mode_config *
+create_save_mode_config_for_port_zone_mode(GHashTable *zones)
 {
-    struct save_targets *targets;
+    struct save_mode_config *zone_based_save_config;
 
     if (zones == NULL) {
         errx(EXIT_FAILURE,
-             "%s: refusing to allocate zone-mode save_targets with NULL "
+             "%s: refusing to allocate zone-mode save_mode_config with NULL "
              "zones (programmer error in caller)", __func__);
     }
 
-    targets = g_malloc0(sizeof(*targets));
-    targets->kind = SAVE_INPUT_PORT_ZONES;
-    targets->zones_to_migrate = zones;
-    return targets;
+    zone_based_save_config = g_malloc0(sizeof(*zone_based_save_config));
+    zone_based_save_config->kind = SAVE_INPUT_PORT_ZONES;
+    zone_based_save_config->zones_to_migrate = zones;
+    return zone_based_save_config;
 }
 
 /**
- * Releases a save_targets bundle and the hashtables it owns.
+ * Releases a save_mode_config bundle and the hashtables it owns.
  *
  * NULL-tolerant.
  *
  * Args:
- *   @targets pointer to the bundle. May be NULL.
+ *   @save_config pointer to the bundle. May be NULL.
  */
 void
-save_targets_destroy(struct save_targets *targets)
+destroy_save_mode_config(struct save_mode_config *save_config)
 {
-    if (targets == NULL) {
+    if (save_config == NULL) {
         return;
     }
 
     /* The two pointers overlay the same memory now, so checking both
      * blindly would double-free the active arm. Dispatch on @kind. */
-    switch (targets->kind) {
+    switch (save_config->kind) {
     case SAVE_INPUT_IPS:
-        if (targets->ips_to_migrate != NULL) {
-            g_hash_table_destroy(targets->ips_to_migrate);
-            targets->ips_to_migrate = NULL;
+        if (save_config->ips_to_migrate != NULL) {
+            g_hash_table_destroy(save_config->ips_to_migrate);
+            save_config->ips_to_migrate = NULL;
         }
         break;
     case SAVE_INPUT_PORT_ZONES:
-        if (targets->zones_to_migrate != NULL) {
-            g_hash_table_destroy(targets->zones_to_migrate);
-            targets->zones_to_migrate = NULL;
+        if (save_config->zones_to_migrate != NULL) {
+            g_hash_table_destroy(save_config->zones_to_migrate);
+            save_config->zones_to_migrate = NULL;
         }
         break;
     }
 
-    g_free(targets);
+    g_free(save_config);
 }
 
 /**
- * Allocates a LOAD targets bundle for the legacy (IP-based) mode.
+ * Allocates a load_mode_config bundle for the legacy (IP-based) mode.
  *
  * Legacy LOAD carries no zone information on the wire and needs no
- * rewrite, so zone_remap is left NULL. apply_zone_rewrite() in
+ * rewrite, so src_dst_zone_map is left NULL. apply_zone_rewrite() in
  * dbus_server.c short-circuits when kind is LOAD_INPUT_LEGACY.
  *
  * Returns:
  *   pointer to the bundle. Process aborts on allocation failure.
  */
-struct load_targets *
-load_targets_new_ips(void)
+struct load_mode_config *
+create_load_mode_config_for_legacy_mode(void)
 {
-    struct load_targets *targets;
+    struct load_mode_config *load_config;
 
-    targets = g_malloc0(sizeof(*targets));
-    targets->kind       = LOAD_INPUT_LEGACY;
-    return targets;
+    load_config = g_malloc0(sizeof(*load_config));
+    load_config->kind = LOAD_INPUT_LEGACY;
+    return load_config;
 }
 
 /**
- * Allocates a LOAD targets bundle that wraps a pre-built
- * (old_zone -> new_zone) remap hashtable.
+ * Allocates a load_mode_config bundle that wraps a pre-built
+ * (old_zone -> new_zone) src-to-dst zone map hashtable.
  *
- * Mirrors save_targets_new_from_zones() on the SAVE side: argv walking
- * lives in main.c (check_zone_load_args, which validates and builds the
- * remap in one pass during pre-fork CLI checking), and this function is
- * a pure wrapper that takes ownership of the remap.
+ * Mirrors create_save_mode_config_for_port_zone_mode() on the SAVE side:
+ * argv walking lives in main.c (check_zone_load_args, which validates
+ * and builds the src-to-dst zone map in one pass during pre-fork CLI
+ * checking), and this function is a pure wrapper that takes ownership
+ * of the map.
  *
  * Args:
- *   @remap  hashtable built by check_zone_load_args(). Must be non-NULL.
- *           Ownership transfers to the returned bundle and is released
- *           by load_targets_destroy().
+ *   @src_dst_zone_map  hashtable built by check_zone_load_args(). Must
+ *                      be non-NULL. Ownership transfers to the returned
+ *                      bundle and is released by destroy_load_mode_config().
  *
  * Returns:
- *   pointer to the bundle. Process aborts on a NULL @remap (caller
- *   contract violation) or on allocation failure.
+ *   pointer to the bundle. Process aborts on a NULL @src_dst_zone_map
+ *   (caller contract violation) or on allocation failure.
  */
-struct load_targets *
-load_targets_new_from_remap(GHashTable *remap)
+struct load_mode_config *
+create_load_mode_config_for_port_zone_mode(GHashTable *src_dst_zone_map)
 {
-    struct load_targets *targets;
+    struct load_mode_config *zone_based_load_config;
 
-    if (remap == NULL) {
+    if (src_dst_zone_map == NULL) {
         errx(EXIT_FAILURE,
-             "%s: refusing to allocate port-zone load_targets with NULL "
-             "remap (programmer error in caller)", __func__);
+             "%s: refusing to allocate port-zone load_mode_config with NULL "
+             "src_dst_zone_map (programmer error in caller)", __func__);
     }
 
-    targets = g_malloc0(sizeof(*targets));
-    targets->kind       = LOAD_INPUT_PORT_ZONES;
-    targets->zone_remap = remap;
-    return targets;
+    zone_based_load_config = g_malloc0(sizeof(*zone_based_load_config));
+    zone_based_load_config->kind = LOAD_INPUT_PORT_ZONES;
+    zone_based_load_config->src_dst_zone_map = src_dst_zone_map;
+    return zone_based_load_config;
 }
 
 /**
- * Releases a load_targets bundle and the hashtable it owns.
+ * Releases a load_mode_config bundle and the hashtable it owns.
  *
  * NULL-tolerant.
  *
  * Args:
- *   @targets pointer to the bundle. May be NULL.
+ *   @load_config pointer to the bundle. May be NULL.
  */
 void
-load_targets_destroy(struct load_targets *targets)
+destroy_load_mode_config(struct load_mode_config *load_config)
 {
-    if (targets == NULL) {
+    if (load_config == NULL) {
         return;
     }
-    if (targets->zone_remap != NULL) {
-        g_hash_table_destroy(targets->zone_remap);
-        targets->zone_remap = NULL;
+    if (load_config->src_dst_zone_map != NULL) {
+        g_hash_table_destroy(load_config->src_dst_zone_map);
+        load_config->src_dst_zone_map = NULL;
     }
-    g_free(targets);
+    g_free(load_config);
 }

--- a/src/common.c
+++ b/src/common.c
@@ -302,3 +302,117 @@ save_targets_destroy(struct save_targets *targets)
 
     g_free(targets);
 }
+
+/**
+ * Allocates a LOAD targets bundle for the legacy (IP-based) mode.
+ *
+ * Legacy LOAD carries no zone information on the wire and needs no
+ * rewrite, so zone_remap is left NULL. apply_zone_rewrite() in
+ * dbus_server.c short-circuits when kind is LOAD_INPUT_LEGACY.
+ *
+ * Returns:
+ *   pointer to the bundle. Process aborts on allocation failure.
+ */
+struct load_targets *
+load_targets_new_ips(void)
+{
+    struct load_targets *targets;
+
+    targets = g_malloc0(sizeof(*targets));
+    targets->kind       = LOAD_INPUT_LEGACY;
+    targets->zone_remap = NULL;
+    return targets;
+}
+
+/**
+ * Builds the LOAD targets bundle for the new port-zone CLI shape.
+ *
+ * Walks argv at the @stride-strided offsets starting from @start_idx.
+ * The port_uuid column at offset 0 is intentionally ignored: at LOAD
+ * time the only thing each CT entry carries is ATTR_ZONE, so the only
+ * usable pivot is old_zone -> new_zone. UUID well-formedness has
+ * already been validated by check_zone_load_args() in main.c.
+ *
+ * If two entries declare the same old_zone with different new_zones,
+ * the last write wins and a WARNING is logged. The CLI validator can
+ * be tightened later to reject this shape outright.
+ *
+ * Args:
+ *   @n_entries  declared N from argv[NUM_ENTRIES_ARG_INDEX].
+ *   @argv       full argv array.
+ *   @start_idx  index of the first per-entry slot (typically
+ *               ENTRIES_LIST_START_ARG_INDEX).
+ *   @stride     LOAD_PORT_ZONE_STRIDE.
+ *
+ * Returns:
+ *   pointer to the bundle on success, NULL on parse failure (in which
+ *   case any partially-built remap is torn down).
+ */
+struct load_targets *
+load_targets_new_from_zone_args(int n_entries, char *argv[], int start_idx,
+                                int stride)
+{
+    struct load_targets *targets;
+    GHashTable *remap;
+    int i;
+
+    remap = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    for (i = 0; i < n_entries; i++) {
+        int base = start_idx + (i * stride);
+        const char *old_str = argv[base + 1];
+        const char *new_str = argv[base + 2];
+        uint16_t old_zone, new_zone;
+
+        if (!parse_ct_zone(old_str, &old_zone) ||
+            !parse_ct_zone(new_str, &new_zone)) {
+            LOG(ERROR, "%s: failed to parse zone at entry %d "
+                "(old='%s' new='%s')",
+                __func__, i, old_str, new_str);
+            g_hash_table_destroy(remap);
+            return NULL;
+        }
+
+        if (g_hash_table_contains(remap,
+                                  GUINT_TO_POINTER((guint) old_zone))) {
+            uint16_t existing = (uint16_t) GPOINTER_TO_UINT(
+                g_hash_table_lookup(remap,
+                    GUINT_TO_POINTER((guint) old_zone)));
+            if (existing != new_zone) {
+                LOG(WARNING, "%s: old_zone %u remapped twice "
+                    "(was -> %u, now -> %u). Last write wins.",
+                    __func__, (unsigned) old_zone,
+                    (unsigned) existing, (unsigned) new_zone);
+            }
+        }
+
+        g_hash_table_insert(remap,
+                            GUINT_TO_POINTER((guint) old_zone),
+                            GUINT_TO_POINTER((guint) new_zone));
+    }
+
+    targets = g_malloc0(sizeof(*targets));
+    targets->kind       = LOAD_INPUT_PORT_ZONES;
+    targets->zone_remap = remap;
+    return targets;
+}
+
+/**
+ * Releases a load_targets bundle and the hashtable it owns.
+ *
+ * NULL-tolerant.
+ *
+ * Args:
+ *   @targets pointer to the bundle. May be NULL.
+ */
+void
+load_targets_destroy(struct load_targets *targets)
+{
+    if (targets == NULL) {
+        return;
+    }
+    if (targets->zone_remap != NULL) {
+        g_hash_table_destroy(targets->zone_remap);
+    }
+    g_free(targets);
+}

--- a/src/common.c
+++ b/src/common.c
@@ -21,8 +21,15 @@
 #include "common.h"
 #include "log.h"
 
-/* Canonical UUID hex string length: 8-4-4-4-12 = 36 chars. */
+/* Canonical UUID body length: 8-4-4-4-12 = 36 chars. */
 #define UUID_STRING_LEN 36
+
+/* Required literal prefix for the port-UUID wire form.
+ * Full accepted shape is: "port_" + <canonical 8-4-4-4-12 UUID>, total 41
+ * characters. The prefix is part of the value supplied by libvirt and is
+ * preserved verbatim in any storage (hashtable keys, log lines, etc.). */
+#define PORT_UUID_PREFIX     "port_"
+#define PORT_UUID_PREFIX_LEN (sizeof(PORT_UUID_PREFIX) - 1)
 
 /**
  * Creates hashtable from IP addresses list.
@@ -80,11 +87,15 @@ create_hashtable_from_ip_list(const char *ip_list[], int num_ips)
 }
 
 /**
- * Validates that @s is a canonical 8-4-4-4-12 hex UUID string.
+ * Validates that @s is a port-prefixed UUID string of the form
+ * "port_<canonical 8-4-4-4-12 hex UUID>" (total length 41).
  *
- * No version/variant bit checks - any 36-char hex-with-hyphens string
- * is accepted. This is intentionally permissive: callers (e.g. libvirt)
- * pass UUIDs in canonical form and we only need to reject obvious junk.
+ * The "port_" prefix is the wire form supplied by libvirt and is part of
+ * the value; this validator rejects bare UUIDs without the prefix. The
+ * UUID body is checked structurally only - dashes at offsets 8/13/18/23
+ * and hex (case-insensitive) everywhere else. No version/variant bit
+ * checks: callers pass canonical UUIDs and we only need to reject
+ * obvious junk.
  *
  * Args:
  *   @s nul-terminated candidate string. May be NULL.
@@ -97,7 +108,15 @@ is_valid_uuid_string(const char *s)
 {
     int i;
 
-    if (s == NULL || strlen(s) != UUID_STRING_LEN) {
+    if (s == NULL) {
+        return false;
+    }
+    if (strncmp(s, PORT_UUID_PREFIX, PORT_UUID_PREFIX_LEN) != 0) {
+        return false;
+    }
+    s += PORT_UUID_PREFIX_LEN;
+
+    if (strlen(s) != UUID_STRING_LEN) {
         return false;
     }
 

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -577,8 +577,22 @@ append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
      * clobber those values. */
     if (nfct_attr_is_set(ct, ATTR_REPL_IPV4_SRC) <= 0) {
         nfct_setobjopt(ct, NFCT_SOPT_SETUP_REPLY);
+    }else{
+        if (nfct_attr_is_set(ct, ATTR_L3PROTO) > 0) {
+            uint8_t l3 = nfct_get_attr_u8(ct, ATTR_L3PROTO);
+            nfct_set_attr_u8(ct, ATTR_REPL_L3PROTO, l3);
+        }
+        if (nfct_attr_is_set(ct, ATTR_L4PROTO) > 0) {
+            uint8_t l4 = nfct_get_attr_u8(ct, ATTR_L4PROTO);
+            nfct_set_attr_u8(ct, ATTR_REPL_L4PROTO, l4);
+        }
     }
-    nfct_nlmsg_build(nlh, ct);
+    
+    if (nfct_nlmsg_build(nlh, ct) < 0) {
+        LOG(ERROR, "%s: seq=%d: nfct_nlmsg_build failed: %s. "
+            "Resulting netlink message is incomplete and the kernel "
+            "will reject it.", __func__, seq, strerror(errno));
+    }
 
     if (label != NULL) {
         mnl_attr_put(nlh, CTA_LABELS, CT_LABEL_NUM_WORDS * WORD_SIZE, label);

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -366,20 +366,21 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
     nfct_nlmsg_parse(nlh, ct);
 
     if (!validate_ct_entry(type, ct, ctx->targets->kind)) {
-        return MNL_CB_OK;
+        goto out;
     }
 
     /* BPF couldn't pre-filter zone-mode events, so do it in-callback. */
     if (ctx->targets->kind == SAVE_INPUT_PORT_ZONES) {
         uint16_t zone = ct_get_migration_zone(ct);
         if (!is_zone_in_hashtable(zone, ctx->targets->zones_to_migrate)) {
-            return MNL_CB_OK;
+            goto out;
         }
     }
 
     update_conntrack_store(conn_store, ct, type, ctx->targets->kind);
-    nfct_destroy(ct);
 
+out:
+    nfct_destroy(ct);
     return MNL_CB_OK;
 }
 
@@ -561,6 +562,12 @@ listen_for_conntrack_events(struct mnl_socket *nl,
  * Also we are using NLM_F_REPLACE flag, which will replace the conntrack
  * entry if already present in the kernel.
  *
+ * On nfct_nlmsg_build failure the partial netlink header is left in the
+ * buffer but no labels are appended; the caller MUST NOT advance the
+ * batch (mnl_nlmsg_batch_next) so the malformed slot gets overwritten by
+ * the next entry. Returning the error makes "knowingly enqueue garbage"
+ * impossible by construction.
+ *
  * Args:
  *   @send_buf buffer to which ct entry is to be appended.
  *   @ct pointer to the conntrack entry to be programmed in CT.
@@ -568,8 +575,10 @@ listen_for_conntrack_events(struct mnl_socket *nl,
  *     in the conntrack entry.
  *   @seq sequence number for ct entry to be used in the batch.
  *
+ * Returns:
+ *   0 on success, -1 if nfct_nlmsg_build failed (caller must drop entry).
  */
-void
+int
 append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
                    uint32_t *label, int seq)
 {
@@ -592,7 +601,7 @@ append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
      * clobber those values. */
     if (nfct_attr_is_set(ct, ATTR_REPL_IPV4_SRC) <= 0) {
         nfct_setobjopt(ct, NFCT_SOPT_SETUP_REPLY);
-    }else{
+    } else {
         if (nfct_attr_is_set(ct, ATTR_L3PROTO) > 0) {
             uint8_t l3 = nfct_get_attr_u8(ct, ATTR_L3PROTO);
             nfct_set_attr_u8(ct, ATTR_REPL_L3PROTO, l3);
@@ -602,16 +611,18 @@ append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
             nfct_set_attr_u8(ct, ATTR_REPL_L4PROTO, l4);
         }
     }
-    
+
     if (nfct_nlmsg_build(nlh, ct) < 0) {
         LOG(ERROR, "%s: seq=%d: nfct_nlmsg_build failed: %s. "
-            "Resulting netlink message is incomplete and the kernel "
-            "will reject it.", __func__, seq, strerror(errno));
+            "Dropping this entry; caller must not advance the batch.",
+            __func__, seq, strerror(errno));
+        return -1;
     }
 
     if (label != NULL) {
         mnl_attr_put(nlh, CTA_LABELS, CT_LABEL_NUM_WORDS * WORD_SIZE, label);
     }
+    return 0;
 }
 
 /**

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -527,8 +527,6 @@ listen_for_conntrack_events(struct mnl_socket *nl,
     int ret = 0;
     int fd;
     char buf[MNL_SOCKET_BUFFER_SIZE];
-    int filter_attach_ret;
-    struct nfct_filter *filter;
     fd_set readfds;  // for select sync IO
     struct timeval tv = {
         .tv_sec = 2,
@@ -543,10 +541,12 @@ listen_for_conntrack_events(struct mnl_socket *nl,
 
     // Attach the IP based filter to the socket. BPF can't filter on CT
     // zone, so zone-mode threads run unfiltered and the callback does the
-    // zone match in-process.
+    // zone match in-process. filter / filter_attach_ret live only inside
+    // this branch -- the zone path never touches them.
     if (targets->kind == SAVE_INPUT_IPS) {
-        filter = create_nfct_filter(targets->ips_to_migrate, is_src_filter);
-        filter_attach_ret = nfct_filter_attach(fd, filter);
+        struct nfct_filter *filter =
+            create_nfct_filter(targets->ips_to_migrate, is_src_filter);
+        int filter_attach_ret = nfct_filter_attach(fd, filter);
         if (filter_attach_ret == -1) {
             LOG(ERROR, "%s: Failed to attach filter to the socket. %s",
                 __func__, strerror(errno));

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -45,23 +45,32 @@ typedef int (*dump_cb)(enum nf_conntrack_msg_type type,
  * Structure to represent the callback arguments for the dump taken before
  * deleting the conntrack entries.
  *
- * Tagged union over the active SAVE sub-mode (same shape as ct_delete_args):
+ * Real C tagged union over the active SAVE sub-mode (same shape as
+ * ct_delete_args):
  *   kind == SAVE_INPUT_IPS         -> ips_migrated / ips_on_host valid.
  *   kind == SAVE_INPUT_PORT_ZONES  -> zones_migrated / zones_on_host valid.
+ * (the two pairs overlay the same memory; only the active arm is set.)
  *
  * ct_store is the per-pass output: CT entries that survive the filter are
  * stolen into it and later iterated for NFCT_Q_DESTROY.
  */
 struct delete_ct_dump_cb_args {
-    enum save_input_kind kind; // selects which set of pointers below is valid
+    enum save_input_kind kind; // selects which arm of the union below is valid
 
-    /* IP mode */
-    GHashTable *ips_migrated; // IPs for which CT entries have been migrated
-    GHashTable *ips_on_host;  // IPs that are currently present on the host
-
-    /* Zone mode */
-    GHashTable *zones_migrated; // CT zones for which entries have been migrated
-    GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
+    /* Active sub-mode state, mirroring struct ct_delete_args. Anonymous
+     * inner structs keep field access flat (cb_args->ips_migrated etc.). */
+    union {
+        /* kind == SAVE_INPUT_IPS */
+        struct {
+            GHashTable *ips_migrated; // IPs for which CT entries have been migrated
+            GHashTable *ips_on_host;  // IPs that are currently present on the host
+        };
+        /* kind == SAVE_INPUT_PORT_ZONES */
+        struct {
+            GHashTable *zones_migrated; // CT zones for which entries have been migrated
+            GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
+        };
+    };
 
     GHashTable *ct_store;     // CT entries to be deleted
 };
@@ -852,13 +861,23 @@ _delete_ct_entries(struct nfct_handle *handle, struct ct_delete_args *args)
     ct_store = g_hash_table_new_full(g_direct_hash, g_direct_equal,
                                      NULL, ct_destroy_g_wrapper);
 
-    // Take conntrack dump to get the entries to be deleted.
-    cb_args.kind            = args->kind;
-    cb_args.ips_migrated    = args->ips_migrated;
-    cb_args.ips_on_host     = args->ips_on_host;
-    cb_args.zones_migrated  = args->zones_migrated;
-    cb_args.zones_on_host   = args->zones_on_host;
-    cb_args.ct_store        = ct_store;
+    /* Take conntrack dump to get the entries to be deleted. Both
+     * structs now use a tagged union for the per-mode pointers, so
+     * we can only touch the arm selected by @kind. Copying both arms
+     * would (a) silently overwrite the active arm with NULLs from the
+     * inactive arm via the union overlap and (b) lie about ownership. */
+    cb_args.kind     = args->kind;
+    cb_args.ct_store = ct_store;
+    switch (args->kind) {
+    case SAVE_INPUT_IPS:
+        cb_args.ips_migrated = args->ips_migrated;
+        cb_args.ips_on_host  = args->ips_on_host;
+        break;
+    case SAVE_INPUT_PORT_ZONES:
+        cb_args.zones_migrated = args->zones_migrated;
+        cb_args.zones_on_host  = args->zones_on_host;
+        break;
+    }
 
     ret = _conntrack_dump(handle, delete_conntrack_dump_callback, &cb_args);
     if (ret == -1) {

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -232,7 +232,7 @@ validate_ct_entry(enum nf_conntrack_msg_type type, const struct nf_conntrack *ct
  *   @type nf message type.
  *   @ct pointer to the conntrack entry received.
  *   @data pointer to the data sent to the callback. In this case it is
- *         a struct save_targets *.
+ *         a struct save_mode_config *.
  *
  * Returns:
  *   NFCT_CB_CONTINUE representing continue processing of
@@ -244,7 +244,7 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
                         void *data)
 {
     bool is_entry_useful;
-    struct save_targets *targets;
+    struct save_mode_config *save_config;
     struct in_addr *src_addr, *dst_addr;
 
     if (ct == NULL) {
@@ -256,18 +256,18 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
         return NFCT_CB_CONTINUE;
     }
 
-    targets = data;
+    save_config = data;
 
-    if (!validate_ct_entry(type, ct, targets->kind)) {
+    if (!validate_ct_entry(type, ct, save_config->kind)) {
         return NFCT_CB_CONTINUE;
     }
 
-    if (targets->kind == SAVE_INPUT_IPS) {
+    if (save_config->kind == SAVE_INPUT_IPS) {
         src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
         dst_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_DST);
 
         is_entry_useful = is_src_or_dst_in_hashtable(src_addr, dst_addr,
-                                                     targets->ips_to_migrate);
+                                                     save_config->ips_to_migrate);
     } else {
         uint16_t zone;
         if (!ct_get_migration_zone(ct, &zone)) {
@@ -276,11 +276,11 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
             return NFCT_CB_CONTINUE;
         }
         is_entry_useful = is_zone_in_hashtable(zone,
-                                               targets->zones_to_migrate);
+                                               save_config->zones_to_migrate);
     }
 
     if (is_entry_useful) {
-        update_conntrack_store(conn_store, ct, type, targets->kind);
+        update_conntrack_store(conn_store, ct, type, save_config->kind);
     }
 
     return NFCT_CB_CONTINUE;
@@ -329,18 +329,19 @@ _conntrack_dump(struct nfct_handle *h, dump_cb cb, void *cb_args)
  *
  * Args:
  *   @handle handle to the netlink socket.
- *   @targets SAVE targets bundle (mode-aware) to filter the CT entries.
+ *   @save_config SAVE-mode config (mode-aware) to filter the CT entries.
  *
  * Returns:
  *   0 if the operation was successful. -1 otherwise.
  */
 int
-get_conntrack_dump(struct nfct_handle *handle, struct save_targets *targets)
+get_conntrack_dump(struct nfct_handle *handle,
+                   struct save_mode_config *save_config)
 {
     int ret;
 
     LOG(INFO, "%s: Conntrack dump start", __func__);
-    ret = _conntrack_dump(handle, conntrack_dump_callback, targets);
+    ret = _conntrack_dump(handle, conntrack_dump_callback, save_config);
     LOG(INFO, "%s: Conntrack dump end", __func__);
 
     return ret;
@@ -354,11 +355,11 @@ get_conntrack_dump(struct nfct_handle *handle, struct save_targets *targets)
  * Closure context for conntrack_events_callback.
  *
  * mnl_cb_run takes a single void *user_data; this struct bundles the
- * SAVE-targets pointer with the stop_flag so the callback can dispatch
- * on kind and exit gracefully.
+ * SAVE-mode config pointer with the stop_flag so the callback can
+ * dispatch on kind and exit gracefully.
  */
 struct events_cb_ctx {
-    struct save_targets *targets;
+    struct save_mode_config *save_config;
     bool *stop_flag;
 };
 
@@ -369,7 +370,7 @@ struct events_cb_ctx {
  * Args:
  *   @nlh pointer to the netlink message header.
  *   @data pointer to the data sent to the callback. Here it's an
- *     events_cb_ctx providing both the targets bundle and the stop_flag.
+ *     events_cb_ctx providing both the SAVE-mode config and the stop_flag.
  *
  * Returns:
  *  - MNL_CB_STOP if we need to stop further event processing.
@@ -418,24 +419,24 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
 
     nfct_nlmsg_parse(nlh, ct);
 
-    if (!validate_ct_entry(type, ct, ctx->targets->kind)) {
+    if (!validate_ct_entry(type, ct, ctx->save_config->kind)) {
         goto out;
     }
 
     /* BPF couldn't pre-filter zone-mode events, so do it in-callback. */
-    if (ctx->targets->kind == SAVE_INPUT_PORT_ZONES) {
+    if (ctx->save_config->kind == SAVE_INPUT_PORT_ZONES) {
         uint16_t zone;
         if (!ct_get_migration_zone(ct, &zone)) {
             LOG(WARNING, "%s: event has no zone attribute; skipping.",
                 __func__);
             goto out;
         }
-        if (!is_zone_in_hashtable(zone, ctx->targets->zones_to_migrate)) {
+        if (!is_zone_in_hashtable(zone, ctx->save_config->zones_to_migrate)) {
             goto out;
         }
     }
 
-    update_conntrack_store(conn_store, ct, type, ctx->targets->kind);
+    update_conntrack_store(conn_store, ct, type, ctx->save_config->kind);
 
 out:
     nfct_destroy(ct);
@@ -495,7 +496,7 @@ create_nfct_filter(GHashTable *ips, bool is_src_filter)
  * events for particular entries based on the filter.
  *
  * This function listens on the netlink socket for the events on particular
- * IPs / CT zones provided via the targets bundle. These events include
+ * IPs / CT zones provided via the SAVE-mode config. These events include
  * create/update/deletion of CT entries.
  *
  * In IP mode a BPF filter is attached on the socket so the kernel only
@@ -509,7 +510,7 @@ create_nfct_filter(GHashTable *ips, bool is_src_filter)
  *
  * Args:
  *   @nl pointer to the netlink socket.
- *   @targets SAVE targets bundle (mode-aware) used for filtering.
+ *   @save_config SAVE-mode config (mode-aware) used for filtering.
  *   @is_src_filter bool representing whether the filter is to be applied
  *     on the source ip or destination ip address. Ignored in zone mode.
  *   @stop_flag pointer to bool passed to the callbacks to stop processing
@@ -520,7 +521,7 @@ create_nfct_filter(GHashTable *ips, bool is_src_filter)
  */
 int
 listen_for_conntrack_events(struct mnl_socket *nl,
-                            struct save_targets *targets,
+                            struct save_mode_config *save_config,
                             bool is_src_filter,
                             bool *stop_flag)
 {
@@ -533,7 +534,7 @@ listen_for_conntrack_events(struct mnl_socket *nl,
         .tv_usec = 0
     };
     struct events_cb_ctx ctx = {
-        .targets = targets,
+        .save_config = save_config,
         .stop_flag = stop_flag,
     };
 
@@ -543,9 +544,9 @@ listen_for_conntrack_events(struct mnl_socket *nl,
     // zone, so zone-mode threads run unfiltered and the callback does the
     // zone match in-process. filter / filter_attach_ret live only inside
     // this branch -- the zone path never touches them.
-    if (targets->kind == SAVE_INPUT_IPS) {
+    if (save_config->kind == SAVE_INPUT_IPS) {
         struct nfct_filter *filter =
-            create_nfct_filter(targets->ips_to_migrate, is_src_filter);
+            create_nfct_filter(save_config->ips_to_migrate, is_src_filter);
         int filter_attach_ret = nfct_filter_attach(fd, filter);
         if (filter_attach_ret == -1) {
             LOG(ERROR, "%s: Failed to attach filter to the socket. %s",

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -44,10 +44,25 @@ typedef int (*dump_cb)(enum nf_conntrack_msg_type type,
 /**
  * Structure to represent the callback arguments for the dump taken before
  * deleting the conntrack entries.
+ *
+ * Tagged union over the active SAVE sub-mode (same shape as ct_delete_args):
+ *   kind == SAVE_INPUT_IPS         -> ips_migrated / ips_on_host valid.
+ *   kind == SAVE_INPUT_PORT_ZONES  -> zones_migrated / zones_on_host valid.
+ *
+ * ct_store is the per-pass output: CT entries that survive the filter are
+ * stolen into it and later iterated for NFCT_Q_DESTROY.
  */
 struct delete_ct_dump_cb_args {
+    enum save_input_kind kind; // selects which set of pointers below is valid
+
+    /* IP mode */
     GHashTable *ips_migrated; // IPs for which CT entries have been migrated
     GHashTable *ips_on_host;  // IPs that are currently present on the host
+
+    /* Zone mode */
+    GHashTable *zones_migrated; // CT zones for which entries have been migrated
+    GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
+
     GHashTable *ct_store;     // CT entries to be deleted
 };
 
@@ -714,30 +729,40 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
                                struct nf_conntrack *ct, void *data)
 {
     struct delete_ct_dump_cb_args *cb_args;
-    struct in_addr *src_addr, *dst_addr;
-    bool in_ips_migrated, in_ips_on_host;
+    bool in_migrated, in_on_host;
 
-    /* Delete path is IP-only today; pass SAVE_INPUT_IPS to keep legacy
-     * behaviour bit-identical. Step 3 will revisit this. */
-    if (!validate_ct_entry(type, ct, SAVE_INPUT_IPS)) {
+    cb_args = data;
+
+    if (!validate_ct_entry(type, ct, cb_args->kind)) {
         return NFCT_CB_CONTINUE;
     }
 
-    cb_args = data;
-    src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
-    dst_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_DST);
-    if (src_addr == NULL || dst_addr == NULL) {
-        LOG(WARNING, "%s: ct entry with NULL src/dst IP received. Skipping.",
-            __func__);
-        return NFCT_CB_FAILURE;
-    }
-    in_ips_migrated = is_src_or_dst_in_hashtable(src_addr, dst_addr,
-                                                 cb_args->ips_migrated);
-    in_ips_on_host = is_src_or_dst_in_hashtable(src_addr, dst_addr,
-                                                cb_args->ips_on_host);
+    if (cb_args->kind == SAVE_INPUT_IPS) {
+        struct in_addr *src_addr, *dst_addr;
 
-    if (in_ips_migrated && !in_ips_on_host) {
+        src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
+        dst_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_DST);
+        if (src_addr == NULL || dst_addr == NULL) {
+            LOG(WARNING, "%s: ct entry with NULL src/dst IP received. "
+                "Skipping.", __func__);
+            return NFCT_CB_FAILURE;
+        }
+
+        in_migrated = is_src_or_dst_in_hashtable(src_addr, dst_addr,
+                                                 cb_args->ips_migrated);
+        in_on_host  = is_src_or_dst_in_hashtable(src_addr, dst_addr,
+                                                 cb_args->ips_on_host);
+    } else {   /* SAVE_INPUT_PORT_ZONES */
+        uint16_t zone = ct_get_migration_zone(ct);
+
+        in_migrated = is_zone_in_hashtable(zone, cb_args->zones_migrated);
+        in_on_host  = (cb_args->zones_on_host != NULL) &&
+                      is_zone_in_hashtable(zone, cb_args->zones_on_host);
+    }
+
+    if (in_migrated && !in_on_host) {
         uint32_t ct_id = nfct_get_attr_u32(ct, ATTR_ID);
+
         if (ct_id == 0) {
             LOG(WARNING, "%s: ct entry with 0 id received. Skipping.",
                 __func__);
@@ -794,22 +819,18 @@ ct_destroy_g_wrapper(void *ct)
  * migration.
  *
  * To clear up the conntrack entries the following procedure is followed:
- *   1. Create hashtables for ips_migrated and ips_on_host.
- *   2. Get the conntrack dump and filter the conntrack entries for which
- *      either of src/dest ips are present in the ips_migrated but not in
- *      ips_on_host.
- *   3. For each of the filtered entry, send the delete call to the netlink
- *      socket.
+ *   1. Take a CT dump from the kernel.
+ *   2. For each dumped entry, decide via the mode-aware filter
+ *      (delete_conntrack_dump_callback) whether it should be deleted.
+ *      Selected entries are stolen into a local ct_store.
+ *   3. For each entry in ct_store, send NFCT_Q_DESTROY to the kernel.
  *
  * Args:
  *   @handle handle to the netlink socket.
- *   @ips_migrated IP addresses for which CT entries have been migrated.
- *   @ips_on_host IP addresses that are currently present on this host.
+ *   @args   delete-thread arguments. Mode-aware via args->kind.
  */
 static void
-_delete_ct_entries(struct nfct_handle *handle,
-                   GHashTable *ips_migrated,
-                   GHashTable *ips_on_host)
+_delete_ct_entries(struct nfct_handle *handle, struct ct_delete_args *args)
 {
     struct delete_ct_dump_cb_args cb_args;
     int ret, failed, success;
@@ -821,9 +842,12 @@ _delete_ct_entries(struct nfct_handle *handle,
                                      NULL, ct_destroy_g_wrapper);
 
     // Take conntrack dump to get the entries to be deleted.
-    cb_args.ips_migrated = ips_migrated;
-    cb_args.ips_on_host = ips_on_host;
-    cb_args.ct_store = ct_store;
+    cb_args.kind            = args->kind;
+    cb_args.ips_migrated    = args->ips_migrated;
+    cb_args.ips_on_host     = args->ips_on_host;
+    cb_args.zones_migrated  = args->zones_migrated;
+    cb_args.zones_on_host   = args->zones_on_host;
+    cb_args.ct_store        = ct_store;
 
     ret = _conntrack_dump(handle, delete_conntrack_dump_callback, &cb_args);
     if (ret == -1) {
@@ -832,8 +856,10 @@ _delete_ct_entries(struct nfct_handle *handle,
         goto finish;
     }
 
-    LOG(INFO, "%s: starting conntrack entry delete. "
-        "Entries to delete %d", __func__, g_hash_table_size(cb_args.ct_store));
+    LOG(INFO, "%s: starting conntrack entry delete (kind=%s). "
+        "Entries to delete %d", __func__,
+        save_input_kind_to_string(args->kind),
+        g_hash_table_size(cb_args.ct_store));
 
     failed = success = 0;
     // Iterate over the ct_store to delete the entries.
@@ -847,8 +873,9 @@ _delete_ct_entries(struct nfct_handle *handle,
         }
     }
 
-    LOG(INFO, "%s: Finished conntrack entry delete. Success: %d, Failed: %d",
-        __func__, success, failed);
+    LOG(INFO, "%s: Finished conntrack entry delete (kind=%s). "
+        "Success: %d, Failed: %d", __func__,
+        save_input_kind_to_string(args->kind), success, failed);
 
 finish:
     if (ct_store != NULL) {
@@ -861,16 +888,18 @@ finish:
  * migration.
  *
  * The following procedure is performed for conntrack entry cleanup:
- * 1. Delete thread is started during initialisation phase of the binary.
- * 2. The ip address passed to the binary are reused as "ips_migrated"
- * 3. The thread waits on the clear_called condition. This dbus-server on
- *    Clear IPC will get the IP addresses present on this host (ips_on_host),
- *    and wake up this thread.
- * 4. The delete procedure is performed afterwards. See _delete_ct_entries for
- *    more details.
+ * 1. Delete thread is started during initialisation phase of the binary
+ *    (in both IP and zone sub-modes; see start_in_save_mode).
+ * 2. The migrated set (ips_to_migrate / zones_to_migrate) is pinned on
+ *    ct_del_args before this thread is created.
+ * 3. The thread waits on the clear_called condition. dbus-server on
+ *    Clear IPC populates the "on host" set (ips_on_host / zones_on_host),
+ *    and wakes up this thread.
+ * 4. The delete procedure is performed afterwards. See _delete_ct_entries
+ *    for more details.
  *
  *  Args:
- *    @data Pointer to the delete arguments.
+ *    @data Pointer to struct ct_delete_args.
  *
  *  Returns:
  *    NULL
@@ -883,7 +912,8 @@ delete_ct_entries(void *data)
 
     ct_del_args = data;
 
-    LOG(INFO, "%s: Starting conntrack delete thread", __func__);
+    LOG(INFO, "%s: Starting conntrack delete thread (kind=%s)", __func__,
+        save_input_kind_to_string(ct_del_args->kind));
     LOG(INFO, "%s: waiting on clear condition.", __func__);
     pthread_mutex_lock(&ct_del_args->mutex);
     while (!ct_del_args->clear_called) {
@@ -897,7 +927,7 @@ delete_ct_entries(void *data)
         goto unlock;
     }
 
-    _delete_ct_entries(h, ct_del_args->ips_migrated, ct_del_args->ips_on_host);
+    _delete_ct_entries(h, ct_del_args);
     nfct_close(h);
 
 unlock:

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -76,22 +76,70 @@ is_src_or_dst_in_hashtable(struct in_addr *src, struct in_addr *dst,
 }
 
 /**
- * Checks if the conntrack entry is valid.
+ * Returns the CT zone we filter on for migration.
  *
- * Conntrack entry is considered valid (migration supported) if:
+ * Prefers ATTR_ZONE, falls back to ATTR_ORIG_ZONE. Caller must have
+ * already validated that at least one of them is set (via validate_ct_entry
+ * in zone mode).
+ *
+ * Args:
+ *   @ct pointer to the conntrack entry.
+ *
+ * Returns:
+ *   the migration zone for @ct.
+ */
+static uint16_t
+ct_get_migration_zone(struct nf_conntrack *ct)
+{
+    if (nfct_attr_is_set(ct, ATTR_ZONE) > 0) {
+        return nfct_get_attr_u16(ct, ATTR_ZONE);
+    }
+    return nfct_get_attr_u16(ct, ATTR_ORIG_ZONE);
+}
+
+/**
+ * Checks if a CT zone is present in the hashtable.
+ *
+ * Mirrors is_src_or_dst_in_hashtable() for zone-keyed hashtables.
+ *
+ * Args:
+ *   @zone CT zone to look up.
+ *   @ht   pointer to the hashtable to perform the lookup.
+ *
+ * Returns:
+ *   true if @zone is present in the hashtable, false otherwise.
+ */
+static bool
+is_zone_in_hashtable(uint16_t zone, GHashTable *ht)
+{
+    return g_hash_table_contains(ht, GUINT_TO_POINTER((guint) zone));
+}
+
+/**
+ * Checks if the conntrack entry is valid for the active SAVE sub-mode.
+ *
+ * Common to both modes:
  *  - source and destination IPv4 addresses are set.
- *  - Zone information is not present.
+ *
+ * IP mode (SAVE_INPUT_IPS):
+ *  - Zone information is not present (legacy paranoid check kept verbatim).
+ *
+ * Zone mode (SAVE_INPUT_PORT_ZONES):
+ *  - At least one of ATTR_ZONE / ATTR_ORIG_ZONE is set so the dispatcher
+ *    has a key to filter on.
  *
  * Args:
  *   @type nf message type.
  *   @ct pointer to the conntrack entry.
+ *   @kind active SAVE sub-mode.
  *
  * Returns:
  *   true in case the CT entry passes the above mentioned checks,
  *   false otherwise
  */
 static bool
-validate_ct_entry(enum nf_conntrack_msg_type type, struct nf_conntrack *ct)
+validate_ct_entry(enum nf_conntrack_msg_type type, struct nf_conntrack *ct,
+                  enum save_input_kind kind)
 {
     if (nfct_attr_is_set(ct, ATTR_ORIG_IPV4_SRC) <= 0 ||
         nfct_attr_is_set(ct, ATTR_ORIG_IPV4_DST) <= 0) {
@@ -105,10 +153,17 @@ validate_ct_entry(enum nf_conntrack_msg_type type, struct nf_conntrack *ct)
         return false;
     }
 
-    if (nfct_attr_is_set(ct, ATTR_ZONE) > 0 ||
-        nfct_attr_is_set(ct, ATTR_ORIG_ZONE) > 0 ||
-        nfct_attr_is_set(ct, ATTR_REPL_ZONE) > 0) {
-        return false;
+    if (kind == SAVE_INPUT_IPS) {
+        if (nfct_attr_is_set(ct, ATTR_ZONE) > 0 ||
+            nfct_attr_is_set(ct, ATTR_ORIG_ZONE) > 0 ||
+            nfct_attr_is_set(ct, ATTR_REPL_ZONE) > 0) {
+            return false;
+        }
+    } else {
+        if (nfct_attr_is_set(ct, ATTR_ZONE) <= 0 &&
+            nfct_attr_is_set(ct, ATTR_ORIG_ZONE) <= 0) {
+            return false;
+        }
     }
 
     return true;
@@ -123,15 +178,16 @@ validate_ct_entry(enum nf_conntrack_msg_type type, struct nf_conntrack *ct)
  * Function called for every ct entry returned during a CT dump call.
  *
  * For every conntrack entry received, if source or destination IP address
- * present in the entry is also present in ips_to_migrate, then update
- * the conntrack store for further processing of the entry, otherwise discard
- * the entry.
+ * present in the entry is also present in ips_to_migrate (IP mode), or the
+ * entry's CT zone is present in zones_to_migrate (zone mode), then update
+ * the conntrack store for further processing of the entry, otherwise
+ * discard the entry.
  *
  * Args:
  *   @type nf message type.
  *   @ct pointer to the conntrack entry received.
  *   @data pointer to the data sent to the callback. In this case it is
- *         ips_to_migrate hashtable.
+ *         a struct save_targets *.
  *
  * Returns:
  *   NFCT_CB_CONTINUE representing continue processing of
@@ -143,23 +199,29 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
                         void *data)
 {
     bool is_entry_useful;
-    GHashTable *ips_to_migrate;
+    struct save_targets *targets;
     struct in_addr *src_addr, *dst_addr;
 
-    ips_to_migrate = data;
+    targets = data;
 
-    if (!validate_ct_entry(type, ct)) {
+    if (!validate_ct_entry(type, ct, targets->kind)) {
         return NFCT_CB_CONTINUE;
     }
 
-    src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
-    dst_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_DST);
+    if (targets->kind == SAVE_INPUT_IPS) {
+        src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
+        dst_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_DST);
 
-    is_entry_useful = is_src_or_dst_in_hashtable(src_addr, dst_addr,
-                                                 ips_to_migrate);
+        is_entry_useful = is_src_or_dst_in_hashtable(src_addr, dst_addr,
+                                                     targets->ips_to_migrate);
+    } else {
+        uint16_t zone = ct_get_migration_zone(ct);
+        is_entry_useful = is_zone_in_hashtable(zone,
+                                               targets->zones_to_migrate);
+    }
 
     if (is_entry_useful) {
-        update_conntrack_store(conn_store, ct, type);
+        update_conntrack_store(conn_store, ct, type, targets->kind);
     }
 
     return NFCT_CB_CONTINUE;
@@ -202,24 +264,24 @@ _conntrack_dump(struct nfct_handle *h, dump_cb cb, void *cb_args)
  * Query the kernel conntrack for CT entries.
  *
  * This function queries the netlink socket for all the conntrack entries
- * present in the system and filters them based on the ip addresses provided
- * in the arguments. Note that this is a blocking call and this function
- * will return only after the response from the netlink socket.
+ * present in the system and filters them based on the migration targets
+ * provided. Note that this is a blocking call and this function will
+ * return only after the response from the netlink socket.
  *
  * Args:
  *   @handle handle to the netlink socket.
- *   @ips_to_migrate IP addresses to be used for filtering the CT entries.
+ *   @targets SAVE targets bundle (mode-aware) to filter the CT entries.
  *
  * Returns:
  *   0 if the operation was successful. -1 otherwise.
  */
 int
-get_conntrack_dump(struct nfct_handle *handle, GHashTable *ips_to_migrate)
+get_conntrack_dump(struct nfct_handle *handle, struct save_targets *targets)
 {
     int ret;
 
     LOG(INFO, "%s: Conntrack dump start", __func__);
-    ret = _conntrack_dump(handle, conntrack_dump_callback, ips_to_migrate);
+    ret = _conntrack_dump(handle, conntrack_dump_callback, targets);
     LOG(INFO, "%s: Conntrack dump end", __func__);
 
     return ret;
@@ -230,13 +292,25 @@ get_conntrack_dump(struct nfct_handle *handle, GHashTable *ips_to_migrate)
 /////////////////////////////////////////////////////////////////////
 
 /**
+ * Closure context for conntrack_events_callback.
+ *
+ * mnl_cb_run takes a single void *user_data; this struct bundles the
+ * SAVE-targets pointer with the stop_flag so the callback can dispatch
+ * on kind and exit gracefully.
+ */
+struct events_cb_ctx {
+    struct save_targets *targets;
+    bool *stop_flag;
+};
+
+/**
  * Function called for every ct entry returned from listening for conntrack
  * events.
  *
  * Args:
  *   @nlh pointer to the netlink message header.
- *   @data pointer to the data sent to the callback. Here it's the
- *     stop_flag which indicates whether to stop processing further events.
+ *   @data pointer to the data sent to the callback. Here it's an
+ *     events_cb_ctx providing both the targets bundle and the stop_flag.
  *
  * Returns:
  *  - MNL_CB_STOP if we need to stop further event processing.
@@ -248,10 +322,10 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
 {
     enum nf_conntrack_msg_type type = NFCT_T_UNKNOWN;
     struct nf_conntrack *ct;
-    bool *stop_flag;
+    struct events_cb_ctx *ctx;
 
-    stop_flag = (bool *)data;
-    if (*stop_flag) {
+    ctx = (struct events_cb_ctx *)data;
+    if (*ctx->stop_flag) {
         return MNL_CB_STOP;
     }
 
@@ -276,11 +350,19 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
 
     nfct_nlmsg_parse(nlh, ct);
 
-    if (!validate_ct_entry(type, ct)) {
+    if (!validate_ct_entry(type, ct, ctx->targets->kind)) {
         return MNL_CB_OK;
     }
 
-    update_conntrack_store(conn_store, ct, type);
+    /* BPF couldn't pre-filter zone-mode events, so do it in-callback. */
+    if (ctx->targets->kind == SAVE_INPUT_PORT_ZONES) {
+        uint16_t zone = ct_get_migration_zone(ct);
+        if (!is_zone_in_hashtable(zone, ctx->targets->zones_to_migrate)) {
+            return MNL_CB_OK;
+        }
+    }
+
+    update_conntrack_store(conn_store, ct, type, ctx->targets->kind);
     nfct_destroy(ct);
 
     return MNL_CB_OK;
@@ -339,8 +421,13 @@ create_nfct_filter(GHashTable *ips, bool is_src_filter)
  * events for particular entries based on the filter.
  *
  * This function listens on the netlink socket for the events on particular
- * IPs provided in the filter. These events include create/update/deletion of
- * CT entry with the particular IP addresses.
+ * IPs / CT zones provided via the targets bundle. These events include
+ * create/update/deletion of CT entries.
+ *
+ * In IP mode a BPF filter is attached on the socket so the kernel only
+ * delivers events for the relevant IPs. BPF cannot match on CT zone, so
+ * in zone mode the socket is left unfiltered and the in-callback dispatch
+ * does the zone match.
  *
  * NOTE: this is a blocking call and this function will return only when the
  * callbacks are unregistered on the handle. Set the stop_flag to prevent any
@@ -348,9 +435,9 @@ create_nfct_filter(GHashTable *ips, bool is_src_filter)
  *
  * Args:
  *   @nl pointer to the netlink socket.
- *   @ips_to_migrate IP addresses to be used for filtering the CT entries.
+ *   @targets SAVE targets bundle (mode-aware) used for filtering.
  *   @is_src_filter bool representing whether the filter is to be applied
- *     on the source ip or destination ip address.
+ *     on the source ip or destination ip address. Ignored in zone mode.
  *   @stop_flag pointer to bool passed to the callbacks to stop processing
  *     any further events.
  *
@@ -359,7 +446,7 @@ create_nfct_filter(GHashTable *ips, bool is_src_filter)
  */
 int
 listen_for_conntrack_events(struct mnl_socket *nl,
-                            GHashTable *ips_to_migrate,
+                            struct save_targets *targets,
                             bool is_src_filter,
                             bool *stop_flag)
 {
@@ -373,19 +460,27 @@ listen_for_conntrack_events(struct mnl_socket *nl,
         .tv_sec = 2,
         .tv_usec = 0
     };
+    struct events_cb_ctx ctx = {
+        .targets = targets,
+        .stop_flag = stop_flag,
+    };
 
     fd = mnl_socket_get_fd(nl);
 
-    // Attach the IP based filter to the socket.
-    filter = create_nfct_filter(ips_to_migrate, is_src_filter);
-    filter_attach_ret = nfct_filter_attach(fd, filter);
-    if (filter_attach_ret == -1) {
-        LOG(ERROR, "%s: Failed to attach filter to the socket. %s", __func__,
-            strerror(errno));
+    // Attach the IP based filter to the socket. BPF can't filter on CT
+    // zone, so zone-mode threads run unfiltered and the callback does the
+    // zone match in-process.
+    if (targets->kind == SAVE_INPUT_IPS) {
+        filter = create_nfct_filter(targets->ips_to_migrate, is_src_filter);
+        filter_attach_ret = nfct_filter_attach(fd, filter);
+        if (filter_attach_ret == -1) {
+            LOG(ERROR, "%s: Failed to attach filter to the socket. %s",
+                __func__, strerror(errno));
+            nfct_filter_destroy(filter);
+            return -1;
+        }
         nfct_filter_destroy(filter);
-        return -1;
     }
-    nfct_filter_destroy(filter);
 
     // Read from the socket using select synchronous IO
     // and every 2 secs check if stop flag is set or not.
@@ -427,7 +522,7 @@ listen_for_conntrack_events(struct mnl_socket *nl,
             break;
         }
 
-        ret = mnl_cb_run(buf, ret, 0, 0, conntrack_events_callback, stop_flag);
+        ret = mnl_cb_run(buf, ret, 0, 0, conntrack_events_callback, &ctx);
         if (ret == MNL_CB_STOP) {
             LOG(INFO, "%s: Stopping the callback", __func__);
             break;
@@ -476,7 +571,13 @@ append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
     nfh->version = NFNETLINK_V0;
     nfh->res_id = 0;
 
-    nfct_setobjopt(ct, NFCT_SOPT_SETUP_REPLY);
+    /* Auto-derive the reply tuple from orig only when the wire didn't
+     * carry one. Zone-mode payloads explicitly carry the reply 5-tuple
+     * (NAT'd flows can have non-swap reply tuples), and SETUP_REPLY would
+     * clobber those values. */
+    if (nfct_attr_is_set(ct, ATTR_REPL_IPV4_SRC) <= 0) {
+        nfct_setobjopt(ct, NFCT_SOPT_SETUP_REPLY);
+    }
     nfct_nlmsg_build(nlh, ct);
 
     if (label != NULL) {
@@ -602,7 +703,9 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
     struct in_addr *src_addr, *dst_addr;
     bool in_ips_migrated, in_ips_on_host;
 
-    if (!validate_ct_entry(type, ct)) {
+    /* Delete path is IP-only today; pass SAVE_INPUT_IPS to keep legacy
+     * behaviour bit-identical. Step 3 will revisit this. */
+    if (!validate_ct_entry(type, ct, SAVE_INPUT_IPS)) {
         return NFCT_CB_CONTINUE;
     }
 

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -47,25 +47,25 @@ typedef int (*dump_cb)(enum nf_conntrack_msg_type type,
  *
  * Real C tagged union over the active SAVE sub-mode (same shape as
  * ct_delete_args):
- *   kind == SAVE_INPUT_IPS         -> ips_migrated / ips_on_host valid.
- *   kind == SAVE_INPUT_PORT_ZONES  -> zones_migrated / zones_on_host valid.
+ *   op_type == SAVE_IPS_OP        -> ips_migrated / ips_on_host valid.
+ *   op_type == SAVE_PORT_ZONE_OP  -> zones_migrated / zones_on_host valid.
  * (the two pairs overlay the same memory; only the active arm is set.)
  *
  * ct_store is the per-pass output: CT entries that survive the filter are
  * stolen into it and later iterated for NFCT_Q_DESTROY.
  */
 struct delete_ct_dump_cb_args {
-    enum save_input_kind kind; // selects which arm of the union below is valid
+    enum save_mode_op_type op_type; // selects which arm of the union below is valid
 
     /* Active sub-mode state, mirroring struct ct_delete_args. Anonymous
      * inner structs keep field access flat (cb_args->ips_migrated etc.). */
     union {
-        /* kind == SAVE_INPUT_IPS */
+        /* op_type == SAVE_IPS_OP */
         struct {
             GHashTable *ips_migrated; // IPs for which CT entries have been migrated
             GHashTable *ips_on_host;  // IPs that are currently present on the host
         };
-        /* kind == SAVE_INPUT_PORT_ZONES */
+        /* op_type == SAVE_PORT_ZONE_OP */
         struct {
             GHashTable *zones_migrated; // CT zones for which entries have been migrated
             GHashTable *zones_on_host;  // CT zones currently owned by ports on this host
@@ -157,17 +157,17 @@ is_zone_in_hashtable(uint16_t zone, GHashTable *ht)
  * Common to both modes:
  *  - source and destination IPv4 addresses are set.
  *
- * IP mode (SAVE_INPUT_IPS):
+ * IP mode (SAVE_IPS_OP):
  *  - Zone information is not present (legacy paranoid check kept verbatim).
  *
- * Zone mode (SAVE_INPUT_PORT_ZONES):
+ * Zone mode (SAVE_PORT_ZONE_OP):
  *  - At least one of ATTR_ZONE / ATTR_ORIG_ZONE is set so the dispatcher
  *    has a key to filter on.
  *
  * Args:
  *   @type nf message type.
  *   @ct pointer to the conntrack entry.
- *   @kind active SAVE sub-mode.
+ *   @op_type active SAVE sub-mode.
  *
  * Returns:
  *   true in case the CT entry passes the above mentioned checks,
@@ -175,7 +175,7 @@ is_zone_in_hashtable(uint16_t zone, GHashTable *ht)
  */
 static bool
 validate_ct_entry(enum nf_conntrack_msg_type type, const struct nf_conntrack *ct,
-                  enum save_input_kind kind)
+                  enum save_mode_op_type op_type)
 {
     if (ct == NULL) {
         LOG(ERROR, "%s: ct is NULL", __func__);
@@ -194,7 +194,7 @@ validate_ct_entry(enum nf_conntrack_msg_type type, const struct nf_conntrack *ct
         return false;
     }
 
-    if (kind == SAVE_INPUT_IPS) {
+    if (op_type == SAVE_IPS_OP) {
         if (nfct_attr_is_set(ct, ATTR_ZONE) > 0 ||
             nfct_attr_is_set(ct, ATTR_ORIG_ZONE) > 0 ||
             nfct_attr_is_set(ct, ATTR_REPL_ZONE) > 0) {
@@ -253,11 +253,11 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
 
     save_config = data;
 
-    if (!validate_ct_entry(type, ct, save_config->kind)) {
+    if (!validate_ct_entry(type, ct, save_config->op_type)) {
         return NFCT_CB_CONTINUE;
     }
 
-    if (save_config->kind == SAVE_INPUT_IPS) {
+    if (save_config->op_type == SAVE_IPS_OP) {
         src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
         dst_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_DST);
 
@@ -275,7 +275,7 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
     }
 
     if (is_entry_useful) {
-        update_conntrack_store(conn_store, ct, type, save_config->kind);
+        update_conntrack_store(conn_store, ct, type, save_config->op_type);
     }
 
     return NFCT_CB_CONTINUE;
@@ -351,7 +351,7 @@ get_conntrack_dump(struct nfct_handle *handle,
  *
  * mnl_cb_run takes a single void *user_data; this struct bundles the
  * SAVE-mode config pointer with the stop_flag so the callback can
- * dispatch on kind and exit gracefully.
+ * dispatch on op_type and exit gracefully.
  */
 struct events_cb_ctx {
     struct save_mode_config *save_config;
@@ -414,12 +414,12 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
 
     nfct_nlmsg_parse(nlh, ct);
 
-    if (!validate_ct_entry(type, ct, ctx->save_config->kind)) {
+    if (!validate_ct_entry(type, ct, ctx->save_config->op_type)) {
         goto out;
     }
 
     /* BPF couldn't pre-filter zone-mode events, so do it in-callback. */
-    if (ctx->save_config->kind == SAVE_INPUT_PORT_ZONES) {
+    if (ctx->save_config->op_type == SAVE_PORT_ZONE_OP) {
         uint16_t zone;
         if (!ct_get_migration_zone(ct, &zone)) {
             LOG(WARNING, "%s: event has no zone attribute; skipping.",
@@ -431,7 +431,7 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
         }
     }
 
-    update_conntrack_store(conn_store, ct, type, ctx->save_config->kind);
+    update_conntrack_store(conn_store, ct, type, ctx->save_config->op_type);
 
 out:
     nfct_destroy(ct);
@@ -539,7 +539,7 @@ listen_for_conntrack_events(struct mnl_socket *nl,
     // zone, so zone-mode threads run unfiltered and the callback does the
     // zone match in-process. filter / filter_attach_ret live only inside
     // this branch -- the zone path never touches them.
-    if (save_config->kind == SAVE_INPUT_IPS) {
+    if (save_config->op_type == SAVE_IPS_OP) {
         struct nfct_filter *filter =
             create_nfct_filter(save_config->ips_to_migrate, is_src_filter);
         int filter_attach_ret = nfct_filter_attach(fd, filter);
@@ -807,11 +807,11 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
 
     cb_args = data;
 
-    if (!validate_ct_entry(type, ct, cb_args->kind)) {
+    if (!validate_ct_entry(type, ct, cb_args->op_type)) {
         return NFCT_CB_CONTINUE;
     }
 
-    if (cb_args->kind == SAVE_INPUT_IPS) {
+    if (cb_args->op_type == SAVE_IPS_OP) {
         struct in_addr *src_addr, *dst_addr;
 
         src_addr = (struct in_addr *)nfct_get_attr(ct, ATTR_ORIG_IPV4_SRC);
@@ -826,7 +826,7 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
                                                  cb_args->ips_migrated);
         in_on_host  = is_src_or_dst_in_hashtable(src_addr, dst_addr,
                                                  cb_args->ips_on_host);
-    } else {   /* SAVE_INPUT_PORT_ZONES */
+    } else {   /* SAVE_PORT_ZONE_OP */
         uint16_t zone;
         if (!ct_get_migration_zone(ct, &zone)) {
             LOG(WARNING, "%s: delete-dump entry has no zone attribute; "
@@ -913,7 +913,7 @@ ct_destroy_g_wrapper(void *ct)
  *
  * Args:
  *   @handle handle to the netlink socket.
- *   @args   delete-thread arguments. Mode-aware via args->kind.
+ *   @args   delete-thread arguments. Mode-aware via args->op_type.
  */
 static void
 _delete_ct_entries(struct nfct_handle *handle, struct ct_delete_args *args)
@@ -929,17 +929,17 @@ _delete_ct_entries(struct nfct_handle *handle, struct ct_delete_args *args)
 
     /* Take conntrack dump to get the entries to be deleted. Both
      * structs now use a tagged union for the per-mode pointers, so
-     * we can only touch the arm selected by @kind. Copying both arms
+     * we can only touch the arm selected by @op_type. Copying both arms
      * would (a) silently overwrite the active arm with NULLs from the
      * inactive arm via the union overlap and (b) lie about ownership. */
-    cb_args.kind     = args->kind;
+    cb_args.op_type  = args->op_type;
     cb_args.ct_store = ct_store;
-    switch (args->kind) {
-    case SAVE_INPUT_IPS:
+    switch (args->op_type) {
+    case SAVE_IPS_OP:
         cb_args.ips_migrated = args->ips_migrated;
         cb_args.ips_on_host  = args->ips_on_host;
         break;
-    case SAVE_INPUT_PORT_ZONES:
+    case SAVE_PORT_ZONE_OP:
         cb_args.zones_migrated = args->zones_migrated;
         cb_args.zones_on_host  = args->zones_on_host;
         break;
@@ -952,9 +952,9 @@ _delete_ct_entries(struct nfct_handle *handle, struct ct_delete_args *args)
         goto finish;
     }
 
-    LOG(INFO, "%s: starting conntrack entry delete (kind=%s). "
+    LOG(INFO, "%s: starting conntrack entry delete (op_type=%s). "
         "Entries to delete %d", __func__,
-        save_input_kind_to_string(args->kind),
+        convert_save_mode_op_type_to_string(args->op_type),
         g_hash_table_size(cb_args.ct_store));
 
     failed = success = 0;
@@ -969,9 +969,9 @@ _delete_ct_entries(struct nfct_handle *handle, struct ct_delete_args *args)
         }
     }
 
-    LOG(INFO, "%s: Finished conntrack entry delete (kind=%s). "
+    LOG(INFO, "%s: Finished conntrack entry delete (op_type=%s). "
         "Success: %d, Failed: %d", __func__,
-        save_input_kind_to_string(args->kind), success, failed);
+        convert_save_mode_op_type_to_string(args->op_type), success, failed);
 
 finish:
     if (ct_store != NULL) {
@@ -1013,8 +1013,8 @@ delete_ct_entries(void *data)
 
     ct_del_args = data;
 
-    LOG(INFO, "%s: Starting conntrack delete thread (kind=%s)", __func__,
-        save_input_kind_to_string(ct_del_args->kind));
+    LOG(INFO, "%s: Starting conntrack delete thread (op_type=%s)", __func__,
+        convert_save_mode_op_type_to_string(ct_del_args->op_type));
     LOG(INFO, "%s: waiting on clear condition.", __func__);
     pthread_mutex_lock(&ct_del_args->mutex);
     while (!ct_del_args->clear_called) {

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -130,10 +130,6 @@ ct_get_migration_zone(const struct nf_conntrack *ct, uint16_t *out)
         *out = nfct_get_attr_u16(ct, ATTR_ZONE);
         return true;
     }
-    if (nfct_attr_is_set(ct, ATTR_ORIG_ZONE) > 0) {
-        *out = nfct_get_attr_u16(ct, ATTR_ORIG_ZONE);
-        return true;
-    }
     return false;
 }
 
@@ -205,8 +201,7 @@ validate_ct_entry(enum nf_conntrack_msg_type type, const struct nf_conntrack *ct
             return false;
         }
     } else {
-        if (nfct_attr_is_set(ct, ATTR_ZONE) <= 0 &&
-            nfct_attr_is_set(ct, ATTR_ORIG_ZONE) <= 0) {
+        if (nfct_attr_is_set(ct, ATTR_ZONE) <= 0) {
             return false;
         }
     }

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -115,7 +115,7 @@ is_src_or_dst_in_hashtable(struct in_addr *src, struct in_addr *dst,
  *   true if a zone was extracted into *out, false otherwise.
  */
 static bool
-ct_get_migration_zone(struct nf_conntrack *ct, uint16_t *out)
+ct_get_migration_zone(const struct nf_conntrack *ct, uint16_t *out)
 {
     if (ct == NULL) {
         LOG(ERROR, "%s: ct is NULL", __func__);
@@ -178,7 +178,7 @@ is_zone_in_hashtable(uint16_t zone, GHashTable *ht)
  *   false otherwise
  */
 static bool
-validate_ct_entry(enum nf_conntrack_msg_type type, struct nf_conntrack *ct,
+validate_ct_entry(enum nf_conntrack_msg_type type, const struct nf_conntrack *ct,
                   enum save_input_kind kind)
 {
     if (ct == NULL) {

--- a/src/conntrack.c
+++ b/src/conntrack.c
@@ -100,25 +100,41 @@ is_src_or_dst_in_hashtable(struct in_addr *src, struct in_addr *dst,
 }
 
 /**
- * Returns the CT zone we filter on for migration.
+ * Returns the CT zone we filter on for migration via an out-parameter.
  *
- * Prefers ATTR_ZONE, falls back to ATTR_ORIG_ZONE. Caller must have
- * already validated that at least one of them is set (via validate_ct_entry
- * in zone mode).
+ * Prefers ATTR_ZONE, falls back to ATTR_ORIG_ZONE. Returns false (without
+ * touching @out) if neither attribute is set, so callers in hot paths can
+ * distinguish "no zone attribute" from a valid zone value of 0 without
+ * relying on validate_ct_entry having run first.
  *
  * Args:
- *   @ct pointer to the conntrack entry.
+ *   @ct  pointer to the conntrack entry. Must be non-NULL.
+ *   @out output uint16_t (only written on success). Must be non-NULL.
  *
  * Returns:
- *   the migration zone for @ct.
+ *   true if a zone was extracted into *out, false otherwise.
  */
-static uint16_t
-ct_get_migration_zone(struct nf_conntrack *ct)
+static bool
+ct_get_migration_zone(struct nf_conntrack *ct, uint16_t *out)
 {
-    if (nfct_attr_is_set(ct, ATTR_ZONE) > 0) {
-        return nfct_get_attr_u16(ct, ATTR_ZONE);
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return false;
     }
-    return nfct_get_attr_u16(ct, ATTR_ORIG_ZONE);
+    if (out == NULL) {
+        LOG(ERROR, "%s: out is NULL", __func__);
+        return false;
+    }
+
+    if (nfct_attr_is_set(ct, ATTR_ZONE) > 0) {
+        *out = nfct_get_attr_u16(ct, ATTR_ZONE);
+        return true;
+    }
+    if (nfct_attr_is_set(ct, ATTR_ORIG_ZONE) > 0) {
+        *out = nfct_get_attr_u16(ct, ATTR_ORIG_ZONE);
+        return true;
+    }
+    return false;
 }
 
 /**
@@ -165,6 +181,11 @@ static bool
 validate_ct_entry(enum nf_conntrack_msg_type type, struct nf_conntrack *ct,
                   enum save_input_kind kind)
 {
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return false;
+    }
+
     if (nfct_attr_is_set(ct, ATTR_ORIG_IPV4_SRC) <= 0 ||
         nfct_attr_is_set(ct, ATTR_ORIG_IPV4_DST) <= 0) {
         char *buf = g_malloc0(1024);
@@ -226,6 +247,15 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
     struct save_targets *targets;
     struct in_addr *src_addr, *dst_addr;
 
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return NFCT_CB_CONTINUE;
+    }
+    if (data == NULL) {
+        LOG(ERROR, "%s: data is NULL", __func__);
+        return NFCT_CB_CONTINUE;
+    }
+
     targets = data;
 
     if (!validate_ct_entry(type, ct, targets->kind)) {
@@ -239,7 +269,12 @@ conntrack_dump_callback(enum nf_conntrack_msg_type type,
         is_entry_useful = is_src_or_dst_in_hashtable(src_addr, dst_addr,
                                                      targets->ips_to_migrate);
     } else {
-        uint16_t zone = ct_get_migration_zone(ct);
+        uint16_t zone;
+        if (!ct_get_migration_zone(ct, &zone)) {
+            LOG(WARNING, "%s: dump entry has no zone attribute; skipping.",
+                __func__);
+            return NFCT_CB_CONTINUE;
+        }
         is_entry_useful = is_zone_in_hashtable(zone,
                                                targets->zones_to_migrate);
     }
@@ -348,6 +383,15 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
     struct nf_conntrack *ct;
     struct events_cb_ctx *ctx;
 
+    if (nlh == NULL) {
+        LOG(ERROR, "%s: nlh is NULL", __func__);
+        return MNL_CB_OK;
+    }
+    if (data == NULL) {
+        LOG(ERROR, "%s: data is NULL", __func__);
+        return MNL_CB_OK;
+    }
+
     ctx = (struct events_cb_ctx *)data;
     if (*ctx->stop_flag) {
         return MNL_CB_STOP;
@@ -380,7 +424,12 @@ conntrack_events_callback(const struct nlmsghdr *nlh, void *data)
 
     /* BPF couldn't pre-filter zone-mode events, so do it in-callback. */
     if (ctx->targets->kind == SAVE_INPUT_PORT_ZONES) {
-        uint16_t zone = ct_get_migration_zone(ct);
+        uint16_t zone;
+        if (!ct_get_migration_zone(ct, &zone)) {
+            LOG(WARNING, "%s: event has no zone attribute; skipping.",
+                __func__);
+            goto out;
+        }
         if (!is_zone_in_hashtable(zone, ctx->targets->zones_to_migrate)) {
             goto out;
         }
@@ -751,6 +800,15 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
     struct delete_ct_dump_cb_args *cb_args;
     bool in_migrated, in_on_host;
 
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return NFCT_CB_CONTINUE;
+    }
+    if (data == NULL) {
+        LOG(ERROR, "%s: data is NULL", __func__);
+        return NFCT_CB_CONTINUE;
+    }
+
     cb_args = data;
 
     if (!validate_ct_entry(type, ct, cb_args->kind)) {
@@ -773,7 +831,12 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
         in_on_host  = is_src_or_dst_in_hashtable(src_addr, dst_addr,
                                                  cb_args->ips_on_host);
     } else {   /* SAVE_INPUT_PORT_ZONES */
-        uint16_t zone = ct_get_migration_zone(ct);
+        uint16_t zone;
+        if (!ct_get_migration_zone(ct, &zone)) {
+            LOG(WARNING, "%s: delete-dump entry has no zone attribute; "
+                "skipping.", __func__);
+            return NFCT_CB_CONTINUE;
+        }
 
         in_migrated = is_zone_in_hashtable(zone, cb_args->zones_migrated);
         in_on_host  = (cb_args->zones_on_host != NULL) &&
@@ -781,7 +844,14 @@ delete_conntrack_dump_callback(enum nf_conntrack_msg_type type,
     }
 
     if (in_migrated && !in_on_host) {
-        uint32_t ct_id = nfct_get_attr_u32(ct, ATTR_ID);
+        uint32_t ct_id;
+
+        if (nfct_attr_is_set(ct, ATTR_ID) <= 0) {
+            LOG(WARNING, "%s: ct entry has no ATTR_ID set; skipping.",
+                __func__);
+            return NFCT_CB_FAILURE;
+        }
+        ct_id = nfct_get_attr_u32(ct, ATTR_ID);
 
         if (ct_id == 0) {
             LOG(WARNING, "%s: ct entry with 0 id received. Skipping.",
@@ -939,6 +1009,11 @@ delete_ct_entries(void *data)
 {
     struct ct_delete_args *ct_del_args;
     struct nfct_handle *h;
+
+    if (data == NULL) {
+        LOG(ERROR, "%s: data is NULL", __func__);
+        return NULL;
+    }
 
     ct_del_args = data;
 

--- a/src/conntrack_entry.c
+++ b/src/conntrack_entry.c
@@ -317,6 +317,11 @@ conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct,
     void *offset;
     enum nf_conntrack_attr nf_ct_attr;
 
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return NULL;
+    }
+
     // Allocate a new conntrack entry.
     ct_entry = conntrack_entry_new();
 
@@ -442,6 +447,15 @@ get_conntrack_entry_from_update(struct conntrack_entry *ct_entry,
     int data_size;
     int i;
     void *res_offset, *offset;
+
+    if (ct_entry == NULL) {
+        LOG(ERROR, "%s: ct_entry is NULL", __func__);
+        return NULL;
+    }
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return NULL;
+    }
 
     res_ct_entry = conntrack_entry_new();
 

--- a/src/conntrack_entry.c
+++ b/src/conntrack_entry.c
@@ -45,7 +45,11 @@ int ct_entry_attr_to_size[CT_ATTR_MAX] = {
     [CT_ATTR_TIMEOUT] = UINT32_T_SIZE,
     [CT_ATTR_MARK] = UINT32_T_SIZE,
     [CT_ATTR_STATUS] = UINT32_T_SIZE,
-    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS
+    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS,
+    [CT_ATTR_L3_SRC_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L3_DST_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L4_SRC_PORT_REPL] = UINT16_T_SIZE,
+    [CT_ATTR_L4_DST_PORT_REPL] = UINT16_T_SIZE
 };
 
 enum nf_conntrack_attr ct_entry_attr_to_nf_attr[CT_ATTR_MAX] = {
@@ -70,6 +74,10 @@ enum nf_conntrack_attr ct_entry_attr_to_nf_attr[CT_ATTR_MAX] = {
     [CT_ATTR_MARK] = ATTR_MARK,
     [CT_ATTR_STATUS] = ATTR_STATUS,
     [CT_ATTR_LABEL] = ATTR_CONNLABELS,
+    [CT_ATTR_L3_SRC_V4_REPL] = ATTR_REPL_IPV4_SRC,
+    [CT_ATTR_L3_DST_V4_REPL] = ATTR_REPL_IPV4_DST,
+    [CT_ATTR_L4_SRC_PORT_REPL] = ATTR_REPL_PORT_SRC,
+    [CT_ATTR_L4_DST_PORT_REPL] = ATTR_REPL_PORT_DST,
 };
 
 /**
@@ -205,20 +213,50 @@ get_data_size_from_bitmap(uint32_t *bm)
 }
 
 /**
+ * True for wire-schema slots that should only appear in zone-mode payloads.
+ *
+ * Used to keep IP-mode payloads byte-identical to the pre-Step-2 wire
+ * format: zone-only slots are skipped during bitmap construction even if
+ * the kernel ct object happens to have the corresponding NF attribute set.
+ *
+ * Args:
+ *   @bit_num index in enum conntrack_entry_attribute.
+ *
+ * Returns:
+ *   true if @bit_num is a zone-mode-only slot.
+ */
+static bool
+is_zone_only_slot(int bit_num)
+{
+    return bit_num == CT_ATTR_L3_SRC_V4_REPL ||
+           bit_num == CT_ATTR_L3_DST_V4_REPL ||
+           bit_num == CT_ATTR_L4_SRC_PORT_REPL ||
+           bit_num == CT_ATTR_L4_DST_PORT_REPL;
+}
+
+/**
  * Sets the bits in the bitmap for all the attributes that are set in the
  * nf_conntrack.
  *
  * Args:
  *   @ct pointer to the nf_conntrack entry
  *   @bm pointer to the bitmap.
+ *   @kind active SAVE sub-mode; controls whether zone-only slots are
+ *         eligible for inclusion.
  */
 static void
-create_bitmap_from_nf_conntrack(struct nf_conntrack *ct, uint32_t *bm)
+create_bitmap_from_nf_conntrack(struct nf_conntrack *ct, uint32_t *bm,
+                                enum save_input_kind kind)
 {
     int i;
 
     for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
         enum nf_conntrack_attr nf_ct_attr;
+
+        if (kind == SAVE_INPUT_IPS && is_zone_only_slot(i)) {
+            continue;
+        }
+
         nf_ct_attr = ct_entry_attr_to_nf_attr[i];
 
         if (nfct_attr_is_set(ct, nf_ct_attr) <= 0) {
@@ -262,12 +300,16 @@ label_from_nf_bitmask(const struct nfct_bitmask *ct_label)
  *
  * Args:
  *   @ct pointer to the nf_conntrack object.
+ *   @kind active SAVE sub-mode; threads down to the bitmap construction
+ *         so IP-mode payloads remain byte-identical to the pre-Step-2
+ *         wire format.
  *
  * Returns:
  *   pointer to the conntrack entry if success, NULL otherwise.
  */
 struct conntrack_entry *
-conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct)
+conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct,
+                                  enum save_input_kind kind)
 {
     struct conntrack_entry *ct_entry;
     int data_size;
@@ -279,7 +321,7 @@ conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct)
     ct_entry = conntrack_entry_new();
 
     // Generate bitmap from nfct conntrack struct.
-    create_bitmap_from_nf_conntrack(ct, ct_entry->bitmap);
+    create_bitmap_from_nf_conntrack(ct, ct_entry->bitmap, kind);
 
     // Use the bitmap to calculate data size.
     data_size = get_data_size_from_bitmap(ct_entry->bitmap);
@@ -337,14 +379,20 @@ err:
  *     stored.
  *   @bm pointer to the first bitmap.
  *   @ct pointer to the netlink conntrack entry.
+ *   @kind active SAVE sub-mode; zone-only slots are skipped in IP mode
+ *         to preserve the legacy wire format.
  */
 static void
-apply_or_operation(uint32_t *res_bm, uint32_t *bm, struct nf_conntrack *ct)
+apply_or_operation(uint32_t *res_bm, uint32_t *bm, struct nf_conntrack *ct,
+                   enum save_input_kind kind)
 {
     enum nf_conntrack_attr nf_ct_attr;
     int i;
 
     for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
+        if (kind == SAVE_INPUT_IPS && is_zone_only_slot(i)) {
+            continue;
+        }
         // If some value is set in the original bitmap. Retain the value.
         if (is_set_in_bitmap(bm, i)) {
             set_bit_in_bitmap(res_bm, i);
@@ -377,6 +425,9 @@ apply_or_operation(uint32_t *res_bm, uint32_t *bm, struct nf_conntrack *ct)
  * Args:
  *   @ct_entry pointer to the original conntrack entry.
  *   @ct pointer to the ct from the nfct events.
+ *   @kind active SAVE sub-mode; threads down to apply_or_operation so
+ *         IP-mode payloads cannot acquire zone-only bits even if the
+ *         kernel update happens to expose those NF attributes.
  *
  * Returns:
  *   pointer to the newly created conntrack entry if successful in applying
@@ -384,7 +435,8 @@ apply_or_operation(uint32_t *res_bm, uint32_t *bm, struct nf_conntrack *ct)
  */
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *ct_entry,
-                                struct nf_conntrack *ct)
+                                struct nf_conntrack *ct,
+                                enum save_input_kind kind)
 {
     struct conntrack_entry *res_ct_entry;
     int data_size;
@@ -394,7 +446,7 @@ get_conntrack_entry_from_update(struct conntrack_entry *ct_entry,
     res_ct_entry = conntrack_entry_new();
 
     // Generate bitmap from nfct conntrack struct.
-    apply_or_operation(res_ct_entry->bitmap, ct_entry->bitmap, ct);
+    apply_or_operation(res_ct_entry->bitmap, ct_entry->bitmap, ct, kind);
 
     // Use the bitmap to calculate data size.
     data_size = get_data_size_from_bitmap(res_ct_entry->bitmap);

--- a/src/conntrack_entry.c
+++ b/src/conntrack_entry.c
@@ -245,7 +245,7 @@ is_zone_only_slot(int bit_num)
  *         eligible for inclusion.
  */
 static void
-create_bitmap_from_nf_conntrack(struct nf_conntrack *ct, uint32_t *bm,
+create_bitmap_from_nf_conntrack(const struct nf_conntrack *ct, uint32_t *bm,
                                 enum save_input_kind kind)
 {
     int i;
@@ -308,7 +308,7 @@ label_from_nf_bitmask(const struct nfct_bitmask *ct_label)
  *   pointer to the conntrack entry if success, NULL otherwise.
  */
 struct conntrack_entry *
-conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct,
+conntrack_entry_from_nf_conntrack(const struct nf_conntrack *ct,
                                   enum save_input_kind kind)
 {
     struct conntrack_entry *ct_entry;
@@ -388,7 +388,7 @@ err:
  *         to preserve the legacy wire format.
  */
 static void
-apply_or_operation(uint32_t *res_bm, uint32_t *bm, struct nf_conntrack *ct,
+apply_or_operation(uint32_t *res_bm, uint32_t *bm, const struct nf_conntrack *ct,
                    enum save_input_kind kind)
 {
     enum nf_conntrack_attr nf_ct_attr;
@@ -440,7 +440,7 @@ apply_or_operation(uint32_t *res_bm, uint32_t *bm, struct nf_conntrack *ct,
  */
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *ct_entry,
-                                struct nf_conntrack *ct,
+                                const struct nf_conntrack *ct,
                                 enum save_input_kind kind)
 {
     struct conntrack_entry *res_ct_entry;

--- a/src/conntrack_entry.c
+++ b/src/conntrack_entry.c
@@ -241,19 +241,19 @@ is_zone_only_slot(int bit_num)
  * Args:
  *   @ct pointer to the nf_conntrack entry
  *   @bm pointer to the bitmap.
- *   @kind active SAVE sub-mode; controls whether zone-only slots are
+ *   @op_type active SAVE sub-mode; controls whether zone-only slots are
  *         eligible for inclusion.
  */
 static void
 create_bitmap_from_nf_conntrack(const struct nf_conntrack *ct, uint32_t *bm,
-                                enum save_input_kind kind)
+                                enum save_mode_op_type op_type)
 {
     int i;
 
     for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
         enum nf_conntrack_attr nf_ct_attr;
 
-        if (kind == SAVE_INPUT_IPS && is_zone_only_slot(i)) {
+        if (op_type == SAVE_IPS_OP && is_zone_only_slot(i)) {
             continue;
         }
 
@@ -300,7 +300,7 @@ label_from_nf_bitmask(const struct nfct_bitmask *ct_label)
  *
  * Args:
  *   @ct pointer to the nf_conntrack object.
- *   @kind active SAVE sub-mode; threads down to the bitmap construction
+ *   @op_type active SAVE sub-mode; threads down to the bitmap construction
  *         so IP-mode payloads remain byte-identical to the pre-Step-2
  *         wire format.
  *
@@ -309,7 +309,7 @@ label_from_nf_bitmask(const struct nfct_bitmask *ct_label)
  */
 struct conntrack_entry *
 conntrack_entry_from_nf_conntrack(const struct nf_conntrack *ct,
-                                  enum save_input_kind kind)
+                                  enum save_mode_op_type op_type)
 {
     struct conntrack_entry *ct_entry;
     int data_size;
@@ -326,7 +326,7 @@ conntrack_entry_from_nf_conntrack(const struct nf_conntrack *ct,
     ct_entry = conntrack_entry_new();
 
     // Generate bitmap from nfct conntrack struct.
-    create_bitmap_from_nf_conntrack(ct, ct_entry->bitmap, kind);
+    create_bitmap_from_nf_conntrack(ct, ct_entry->bitmap, op_type);
 
     // Use the bitmap to calculate data size.
     data_size = get_data_size_from_bitmap(ct_entry->bitmap);
@@ -384,18 +384,18 @@ err:
  *     stored.
  *   @bm pointer to the first bitmap.
  *   @ct pointer to the netlink conntrack entry.
- *   @kind active SAVE sub-mode; zone-only slots are skipped in IP mode
+ *   @op_type active SAVE sub-mode; zone-only slots are skipped in IP mode
  *         to preserve the legacy wire format.
  */
 static void
 apply_or_operation(uint32_t *res_bm, uint32_t *bm, const struct nf_conntrack *ct,
-                   enum save_input_kind kind)
+                   enum save_mode_op_type op_type)
 {
     enum nf_conntrack_attr nf_ct_attr;
     int i;
 
     for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
-        if (kind == SAVE_INPUT_IPS && is_zone_only_slot(i)) {
+        if (op_type == SAVE_IPS_OP && is_zone_only_slot(i)) {
             continue;
         }
         // If some value is set in the original bitmap. Retain the value.
@@ -430,7 +430,7 @@ apply_or_operation(uint32_t *res_bm, uint32_t *bm, const struct nf_conntrack *ct
  * Args:
  *   @ct_entry pointer to the original conntrack entry.
  *   @ct pointer to the ct from the nfct events.
- *   @kind active SAVE sub-mode; threads down to apply_or_operation so
+ *   @op_type active SAVE sub-mode; threads down to apply_or_operation so
  *         IP-mode payloads cannot acquire zone-only bits even if the
  *         kernel update happens to expose those NF attributes.
  *
@@ -441,7 +441,7 @@ apply_or_operation(uint32_t *res_bm, uint32_t *bm, const struct nf_conntrack *ct
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *ct_entry,
                                 const struct nf_conntrack *ct,
-                                enum save_input_kind kind)
+                                enum save_mode_op_type op_type)
 {
     struct conntrack_entry *res_ct_entry;
     int data_size;
@@ -460,7 +460,7 @@ get_conntrack_entry_from_update(struct conntrack_entry *ct_entry,
     res_ct_entry = conntrack_entry_new();
 
     // Generate bitmap from nfct conntrack struct.
-    apply_or_operation(res_ct_entry->bitmap, ct_entry->bitmap, ct, kind);
+    apply_or_operation(res_ct_entry->bitmap, ct_entry->bitmap, ct, op_type);
 
     // Use the bitmap to calculate data size.
     data_size = get_data_size_from_bitmap(res_ct_entry->bitmap);

--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -93,7 +93,7 @@ conntrack_store_destroy(struct conntrack_store *conn_store)
 static int
 conntrack_store_insert(struct conntrack_store *conn_store,
                        const struct nf_conntrack *ct,
-                       enum save_input_kind kind)
+                       enum save_mode_op_type op_type)
 {
     uint32_t ct_id;
     struct conntrack_entry *ct_entry;
@@ -113,7 +113,7 @@ conntrack_store_insert(struct conntrack_store *conn_store,
         return -1;
     }
 
-    ct_entry = conntrack_entry_from_nf_conntrack(ct, kind);
+    ct_entry = conntrack_entry_from_nf_conntrack(ct, op_type);
     if (ct_entry == NULL) {
         LOG(WARNING, "%s: received ct_entry as NULL", __func__);
         return -1;
@@ -179,9 +179,9 @@ conntrack_store_remove(struct conntrack_store *conn_store,
 static void
 handle_new_event(struct conntrack_store *conn_store,
                  const struct nf_conntrack *ct,
-                 enum save_input_kind kind)
+                 enum save_mode_op_type op_type)
 {
-    conntrack_store_insert(conn_store, ct, kind);
+    conntrack_store_insert(conn_store, ct, op_type);
 }
 
 /**
@@ -200,7 +200,7 @@ handle_new_event(struct conntrack_store *conn_store,
 static void
 handle_update_event(struct conntrack_store *conn_store,
                     const struct nf_conntrack *ct,
-                    enum save_input_kind kind)
+                    enum save_mode_op_type op_type)
 {
     uint32_t ct_id;
     struct conntrack_entry *ct_entry;
@@ -222,9 +222,9 @@ handle_update_event(struct conntrack_store *conn_store,
     if (ct_entry == NULL) {
         LOG(VERBOSE, "%s: Update received for a non-existent entry. "
             "Treating it as NEW.", __func__);
-        res_ct_entry = conntrack_entry_from_nf_conntrack(ct, kind);
+        res_ct_entry = conntrack_entry_from_nf_conntrack(ct, op_type);
     } else {
-        res_ct_entry = get_conntrack_entry_from_update(ct_entry, ct, kind);
+        res_ct_entry = get_conntrack_entry_from_update(ct_entry, ct, op_type);
     }
 
     if (res_ct_entry == NULL) {
@@ -271,14 +271,14 @@ handle_destroy_event(struct conntrack_store *conn_store,
  *    @ct pointer to the nf_conntrack entry received as part of the
  *        netlink event.
  *    @type event type. (NEW/UPDATE/DESTROY)
- *    @kind active SAVE sub-mode; threaded through to entry construction
+ *    @op_type active SAVE sub-mode; threaded through to entry construction
  *          so the wire-format bitmap stays mode-correct.
  */
 void
 update_conntrack_store(struct conntrack_store *conn_store,
                        const struct nf_conntrack *ct,
                        enum nf_conntrack_msg_type type,
-                       enum save_input_kind kind)
+                       enum save_mode_op_type op_type)
 {
     if (ct == NULL) {
         LOG(ERROR, "%s: ct is NULL", __func__);
@@ -287,10 +287,10 @@ update_conntrack_store(struct conntrack_store *conn_store,
 
     switch(type) {
     case NFCT_T_NEW:
-        handle_new_event(conn_store, ct, kind);
+        handle_new_event(conn_store, ct, op_type);
         break;
     case NFCT_T_UPDATE:
-        handle_update_event(conn_store, ct, kind);
+        handle_update_event(conn_store, ct, op_type);
         break;
     case NFCT_T_DESTROY:
         handle_destroy_event(conn_store, ct);

--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -92,11 +92,16 @@ conntrack_store_destroy(struct conntrack_store *conn_store)
  */
 static int
 conntrack_store_insert(struct conntrack_store *conn_store,
-                       struct nf_conntrack *ct,
+                       const struct nf_conntrack *ct,
                        enum save_input_kind kind)
 {
     uint32_t ct_id;
     struct conntrack_entry *ct_entry;
+    
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return -1;
+    }
 
     if (nfct_attr_is_set(ct, ATTR_ID) <= 0) {
         LOG(WARNING, "%s: ct has no ATTR_ID; skipping.", __func__);
@@ -137,9 +142,14 @@ conntrack_store_insert(struct conntrack_store *conn_store,
  */
 static int
 conntrack_store_remove(struct conntrack_store *conn_store,
-                       struct nf_conntrack *ct)
+                       const struct nf_conntrack *ct)
 {
     uint32_t ct_id;
+    
+    if (conn_store == NULL) {
+        LOG(ERROR, "%s: conn_store is NULL", __func__);
+        return -1;
+    }
 
     if (nfct_attr_is_set(ct, ATTR_ID) <= 0) {
         return -1;
@@ -168,7 +178,7 @@ conntrack_store_remove(struct conntrack_store *conn_store,
  */
 static void
 handle_new_event(struct conntrack_store *conn_store,
-                 struct nf_conntrack *ct,
+                 const struct nf_conntrack *ct,
                  enum save_input_kind kind)
 {
     conntrack_store_insert(conn_store, ct, kind);
@@ -189,7 +199,7 @@ handle_new_event(struct conntrack_store *conn_store,
  */
 static void
 handle_update_event(struct conntrack_store *conn_store,
-                    struct nf_conntrack *ct,
+                    const struct nf_conntrack *ct,
                     enum save_input_kind kind)
 {
     uint32_t ct_id;
@@ -236,7 +246,7 @@ handle_update_event(struct conntrack_store *conn_store,
  */
 static void
 handle_destroy_event(struct conntrack_store *conn_store,
-                     struct nf_conntrack *ct)
+                     const struct nf_conntrack *ct)
 {
     int ret = conntrack_store_remove(conn_store, ct);
     if (ret == -1) {
@@ -266,14 +276,10 @@ handle_destroy_event(struct conntrack_store *conn_store,
  */
 void
 update_conntrack_store(struct conntrack_store *conn_store,
-                       struct nf_conntrack *ct,
+                       const struct nf_conntrack *ct,
                        enum nf_conntrack_msg_type type,
                        enum save_input_kind kind)
 {
-    if (conn_store == NULL) {
-        LOG(ERROR, "%s: conn_store is NULL", __func__);
-        return;
-    }
     if (ct == NULL) {
         LOG(ERROR, "%s: ct is NULL", __func__);
         return;

--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -68,6 +68,7 @@ conntrack_store_destroy(struct conntrack_store *conn_store)
 
     if (conn_store->store != NULL) {
         g_hash_table_destroy(conn_store->store);
+        conn_store->store = NULL;
     }
 
     pthread_mutex_destroy(&conn_store->lock);
@@ -97,6 +98,10 @@ conntrack_store_insert(struct conntrack_store *conn_store,
     uint32_t ct_id;
     struct conntrack_entry *ct_entry;
 
+    if (nfct_attr_is_set(ct, ATTR_ID) <= 0) {
+        LOG(WARNING, "%s: ct has no ATTR_ID; skipping.", __func__);
+        return -1;
+    }
     ct_id = nfct_get_attr_u32(ct, ATTR_ID);
     if (ct_id == 0) {
         LOG(WARNING, "%s: CT with ID = 0 received!", __func__);
@@ -136,7 +141,10 @@ conntrack_store_remove(struct conntrack_store *conn_store,
 {
     uint32_t ct_id;
 
-    ct_id= nfct_get_attr_u32(ct, ATTR_ID);
+    if (nfct_attr_is_set(ct, ATTR_ID) <= 0) {
+        return -1;
+    }
+    ct_id = nfct_get_attr_u32(ct, ATTR_ID);
     if (ct_id == 0) {
         return -1;
     }
@@ -188,6 +196,10 @@ handle_update_event(struct conntrack_store *conn_store,
     struct conntrack_entry *ct_entry;
     struct conntrack_entry *res_ct_entry;
 
+    if (nfct_attr_is_set(ct, ATTR_ID) <= 0) {
+        LOG(WARNING, "%s: ct has no ATTR_ID; skipping.", __func__);
+        return;
+    }
     ct_id = nfct_get_attr_u32(ct, ATTR_ID);
     if (ct_id == 0) {
         LOG(WARNING, "%s: ct entry with 0 id received. Skipping.", __func__);
@@ -258,6 +270,15 @@ update_conntrack_store(struct conntrack_store *conn_store,
                        enum nf_conntrack_msg_type type,
                        enum save_input_kind kind)
 {
+    if (conn_store == NULL) {
+        LOG(ERROR, "%s: conn_store is NULL", __func__);
+        return;
+    }
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return;
+    }
+
     switch(type) {
     case NFCT_T_NEW:
         handle_new_event(conn_store, ct, kind);

--- a/src/conntrack_store.c
+++ b/src/conntrack_store.c
@@ -91,7 +91,8 @@ conntrack_store_destroy(struct conntrack_store *conn_store)
  */
 static int
 conntrack_store_insert(struct conntrack_store *conn_store,
-                       struct nf_conntrack *ct)
+                       struct nf_conntrack *ct,
+                       enum save_input_kind kind)
 {
     uint32_t ct_id;
     struct conntrack_entry *ct_entry;
@@ -102,7 +103,7 @@ conntrack_store_insert(struct conntrack_store *conn_store,
         return -1;
     }
 
-    ct_entry = conntrack_entry_from_nf_conntrack(ct);
+    ct_entry = conntrack_entry_from_nf_conntrack(ct, kind);
     if (ct_entry == NULL) {
         LOG(WARNING, "%s: received ct_entry as NULL", __func__);
         return -1;
@@ -159,9 +160,10 @@ conntrack_store_remove(struct conntrack_store *conn_store,
  */
 static void
 handle_new_event(struct conntrack_store *conn_store,
-                 struct nf_conntrack *ct)
+                 struct nf_conntrack *ct,
+                 enum save_input_kind kind)
 {
-    conntrack_store_insert(conn_store, ct);
+    conntrack_store_insert(conn_store, ct, kind);
 }
 
 /**
@@ -179,7 +181,8 @@ handle_new_event(struct conntrack_store *conn_store,
  */
 static void
 handle_update_event(struct conntrack_store *conn_store,
-                    struct nf_conntrack *ct)
+                    struct nf_conntrack *ct,
+                    enum save_input_kind kind)
 {
     uint32_t ct_id;
     struct conntrack_entry *ct_entry;
@@ -197,9 +200,9 @@ handle_update_event(struct conntrack_store *conn_store,
     if (ct_entry == NULL) {
         LOG(VERBOSE, "%s: Update received for a non-existent entry. "
             "Treating it as NEW.", __func__);
-        res_ct_entry = conntrack_entry_from_nf_conntrack(ct);
+        res_ct_entry = conntrack_entry_from_nf_conntrack(ct, kind);
     } else {
-        res_ct_entry = get_conntrack_entry_from_update(ct_entry, ct);
+        res_ct_entry = get_conntrack_entry_from_update(ct_entry, ct, kind);
     }
 
     if (res_ct_entry == NULL) {
@@ -246,18 +249,21 @@ handle_destroy_event(struct conntrack_store *conn_store,
  *    @ct pointer to the nf_conntrack entry received as part of the
  *        netlink event.
  *    @type event type. (NEW/UPDATE/DESTROY)
+ *    @kind active SAVE sub-mode; threaded through to entry construction
+ *          so the wire-format bitmap stays mode-correct.
  */
 void
 update_conntrack_store(struct conntrack_store *conn_store,
                        struct nf_conntrack *ct,
-                       enum nf_conntrack_msg_type type)
+                       enum nf_conntrack_msg_type type,
+                       enum save_input_kind kind)
 {
     switch(type) {
     case NFCT_T_NEW:
-        handle_new_event(conn_store, ct);
+        handle_new_event(conn_store, ct, kind);
         break;
     case NFCT_T_UPDATE:
-        handle_update_event(conn_store, ct);
+        handle_update_event(conn_store, ct, kind);
         break;
     case NFCT_T_DESTROY:
         handle_destroy_event(conn_store, ct);

--- a/src/data_template.c
+++ b/src/data_template.c
@@ -24,16 +24,16 @@
 #include "data_template.h"
 
 /**
- * Allocates a new data_template sized to @kind.
+ * Allocates a new data_template sized to @op_type.
  *
- * See the header for the per-kind wire-format contract.
+ * See the header for the per-op_type wire-format contract.
  *
  * Returns:
  *   pointer to the allocated memory if success.
  *   In case of error, terminates the process.
  */
 struct data_template *
-data_template_new(enum save_input_kind kind)
+data_template_new(enum save_mode_op_type op_type)
 {
     struct data_template *data_tmpl;
     int i;
@@ -44,7 +44,7 @@ data_template_new(enum save_input_kind kind)
      * Zone mode advertises every slot the current binary understands.
      * The trailing slots are gated off in IP mode by is_zone_only_slot()
      * (conntrack_entry.c) so they are never set in any bitmap either. */
-    num_bits = (kind == SAVE_INPUT_IPS) ? CT_ATTR_LEGACY_NUM_BITS
+    num_bits = (op_type == SAVE_IPS_OP) ? CT_ATTR_LEGACY_NUM_BITS
                                         : CT_ATTR_MAX;
 
     data_tmpl = g_malloc0(sizeof(struct data_template));

--- a/src/data_template.c
+++ b/src/data_template.c
@@ -24,24 +24,35 @@
 #include "data_template.h"
 
 /**
- * Allocates a new data_template and intialises all its fields.
+ * Allocates a new data_template sized to @kind.
+ *
+ * See the header for the per-kind wire-format contract.
  *
  * Returns:
  *   pointer to the allocated memory if success.
  *   In case of error, terminates the process.
  */
 struct data_template *
-data_template_new(void)
+data_template_new(enum save_input_kind kind)
 {
     struct data_template *data_tmpl;
     int i;
+    uint8_t num_bits;
+
+    /* Wire-compat: IP mode advertises only the v1.0 schema so the
+     * payload is byte-identical to what a v1.0 SAVE binary produces.
+     * Zone mode advertises every slot the current binary understands.
+     * The trailing slots are gated off in IP mode by is_zone_only_slot()
+     * (conntrack_entry.c) so they are never set in any bitmap either. */
+    num_bits = (kind == SAVE_INPUT_IPS) ? CT_ATTR_LEGACY_NUM_BITS
+                                        : CT_ATTR_MAX;
 
     data_tmpl = g_malloc0(sizeof(struct data_template));
-    data_tmpl->num_bits = CT_ATTR_MAX;
-    data_tmpl->payload_size = CT_ATTR_MAX * UINT8_T_SIZE;
-    data_tmpl->payload = g_malloc0(sizeof(uint8_t) * CT_ATTR_MAX);
+    data_tmpl->num_bits = num_bits;
+    data_tmpl->payload_size = num_bits * UINT8_T_SIZE;
+    data_tmpl->payload = g_malloc0(sizeof(uint8_t) * num_bits);
 
-    for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
+    for (i = CT_ATTR_MIN; i < num_bits; i++) {
         data_tmpl->payload[i] = ct_entry_attr_to_size[i];
     }
 

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -328,13 +328,23 @@ complete_on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation)
 /**
  * RPC endpoint for Clear message.
  *
- * This function is called at the source host. At the end of
- * successful migration, we want to remove the CT entries of the VM that has
- * been migrated from the host. This function receives the list of ip_address
- * that are currently present on this host. The list of ip_address that have
- * been migrated are already available to us when we started the helper.
- * Thus, on receiving the clear call we signal the conntrack delete thread to
- * clear the migrated conntrack entries.
+ * Called at the source host at the end of a successful migration to
+ * remove the CT entries of the VM that has been migrated.
+ *
+ * Payload shape, in both modes, is "as" (array of strings). The
+ * interpretation depends on the helper's active SAVE sub-mode, which
+ * is fixed at start-up in start_in_save_mode and recorded on
+ * ct_del_args.kind (an extern global declared in ct_delete_args.h):
+ *
+ *   - IP mode  (SAVE_INPUT_IPS)        : each string is an IPv4 address
+ *                                        currently present on this host.
+ *   - Zone mode (SAVE_INPUT_PORT_ZONES): each string is a decimal CT zone
+ *                                        currently owned by a port still
+ *                                        on this host.
+ *
+ * On success the parsed set is published to ct_del_args under the lock,
+ * the clear_called condition is signalled, and the delete thread wakes
+ * up to do the actual NFCT_Q_DESTROY work.
  *
  * NOTE: the reason for performing this operation asynchronously is that
  * migrate task should not be held up just for the cleanup. And also since
@@ -357,31 +367,49 @@ static gboolean
 on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
                  const gchar *arg_data, gpointer user_data)
 {
-    LOG(INFO, "%s: Clear start", __func__);
+    LOG(INFO, "%s: Clear start (kind=%s)", __func__,
+        save_input_kind_to_string(ct_del_args.kind));
     GVariant *args, *var;
-    gsize num_ip_address = 0;
-    char **ip_addresses;
-    GHashTable *ips_on_host;
+    gsize num_entries = 0;
+    char **payload;
+    GHashTable *ips_on_host   = NULL;
+    GHashTable *zones_on_host = NULL;
+    bool parse_ok;
 
     args = g_dbus_method_invocation_get_parameters(invocation);
     var = g_variant_get_child_value(args, 0);
-    ip_addresses = g_variant_dup_strv(var, &num_ip_address);
+    payload = g_variant_dup_strv(var, &num_entries);
 
-    ips_on_host = create_hashtable_from_ip_list((const char **)ip_addresses,
-                                                num_ip_address);
-    g_strfreev(ip_addresses);
-    if (ips_on_host == NULL) {
-        LOG(ERROR, "%s: Failed to create ips_on_host", __func__);
+    if (ct_del_args.kind == SAVE_INPUT_IPS) {
+        ips_on_host = create_hashtable_from_ip_list(
+                          (const char **)payload, num_entries);
+        parse_ok = (ips_on_host != NULL);
+    } else {   /* SAVE_INPUT_PORT_ZONES */
+        zones_on_host = create_hashtable_from_zone_str_list(
+                            (const char **)payload, num_entries);
+        parse_ok = (zones_on_host != NULL);
+    }
+    g_strfreev(payload);
+
+    if (!parse_ok) {
+        LOG(ERROR, "%s: Failed to parse %s payload", __func__,
+            ct_del_args.kind == SAVE_INPUT_IPS ? "ips_on_host"
+                                              : "zones_on_host");
         return complete_on_clear(object, invocation);
     }
 
     pthread_mutex_lock(&ct_del_args.mutex);
-    ct_del_args.ips_on_host = ips_on_host;
+    if (ct_del_args.kind == SAVE_INPUT_IPS) {
+        ct_del_args.ips_on_host = ips_on_host;
+    } else {
+        ct_del_args.zones_on_host = zones_on_host;
+    }
     ct_del_args.clear_called = true;
     pthread_cond_signal(&ct_del_args.clear_called_cond);
     pthread_mutex_unlock(&ct_del_args.mutex);
 
-    LOG(INFO, "%s: Clear completed", __func__);
+    LOG(INFO, "%s: Clear completed (received %zu %s)", __func__, num_entries,
+        ct_del_args.kind == SAVE_INPUT_IPS ? "IPs" : "zones");
     return complete_on_clear(object, invocation);
 }
 

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -84,7 +84,7 @@ apply_zone_rewrite(struct nf_conntrack *ct,
         return false;
     }
 
-    if (load_config == NULL || load_config->kind == LOAD_INPUT_LEGACY) {
+    if (load_config == NULL || load_config->op_type == LOAD_IPS_OP) {
         return true;
     }
 
@@ -309,7 +309,7 @@ on_save(VMState1 *object, GDBusMethodInvocation *invocation, gpointer user_data)
     // gracefully exit.
     *(targs->stop_flag) = true;
 
-    data_tmpl = data_template_new(targs->save_kind);
+    data_tmpl = data_template_new(targs->save_op_type);
 
     buf = marshal(conn_store, data_tmpl, &data_size);
     if (buf == NULL) {
@@ -350,13 +350,13 @@ complete_on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation)
  * Payload shape, in both modes, is "as" (array of strings). The
  * interpretation depends on the helper's active SAVE sub-mode, which
  * is fixed at start-up in start_in_save_mode and recorded on
- * ct_del_args.kind (an extern global declared in ct_delete_args.h):
+ * ct_del_args.op_type (an extern global declared in ct_delete_args.h):
  *
- *   - IP mode  (SAVE_INPUT_IPS)        : each string is an IPv4 address
- *                                        currently present on this host.
- *   - Zone mode (SAVE_INPUT_PORT_ZONES): a flat strv of paired entries
- *                                        [port_uuid_0, zone_0,
- *                                         port_uuid_1, zone_1, ...] where
+ *   - IP mode  (SAVE_IPS_OP)        : each string is an IPv4 address
+ *                                     currently present on this host.
+ *   - Zone mode (SAVE_PORT_ZONE_OP) : a flat strv of paired entries
+ *                                     [port_uuid_0, zone_0,
+ *                                      port_uuid_1, zone_1, ...] where
  *                                        each zone is a decimal CT zone
  *                                        currently owned by the named
  *                                        port still on this host. Length
@@ -388,8 +388,8 @@ static gboolean
 on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
                  const gchar *arg_data, gpointer user_data)
 {
-    LOG(INFO, "%s: Clear start (kind=%s)", __func__,
-        save_input_kind_to_string(ct_del_args.kind));
+    LOG(INFO, "%s: Clear start (op_type=%s)", __func__,
+        convert_save_mode_op_type_to_string(ct_del_args.op_type));
     GVariant *args, *var;
     gsize num_entries = 0;
     char **payload;
@@ -416,7 +416,7 @@ on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
     /* Zone-mode clear payload is paired (port_uuid, zone). Catch a
      * malformed odd-length strv up front so the parser doesn't have to
      * own this protocol-level invariant on its own. */
-    if (ct_del_args.kind == SAVE_INPUT_PORT_ZONES &&
+    if (ct_del_args.op_type == SAVE_PORT_ZONE_OP &&
         (num_entries % 2) != 0) {
         LOG(ERROR, "%s: zone-mode clear payload must be paired "
             "(port_uuid, zone); got odd length %zu",
@@ -425,11 +425,11 @@ on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
         return complete_on_clear(object, invocation);
     }
 
-    if (ct_del_args.kind == SAVE_INPUT_IPS) {
+    if (ct_del_args.op_type == SAVE_IPS_OP) {
         ips_on_host = create_hashtable_from_ip_list(
                           (const char **)payload, (int) num_entries);
         parse_ok = (ips_on_host != NULL);
-    } else {   /* SAVE_INPUT_PORT_ZONES */
+    } else {   /* SAVE_PORT_ZONE_OP */
         zones_on_host = create_hashtable_from_port_zone_pairs(
                             (const char **)payload, (int) num_entries);
         parse_ok = (zones_on_host != NULL);
@@ -438,13 +438,13 @@ on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
 
     if (!parse_ok) {
         LOG(ERROR, "%s: Failed to parse %s payload", __func__,
-            ct_del_args.kind == SAVE_INPUT_IPS ? "ips_on_host"
-                                              : "zones_on_host");
+            ct_del_args.op_type == SAVE_IPS_OP ? "ips_on_host"
+                                               : "zones_on_host");
         return complete_on_clear(object, invocation);
     }
 
     pthread_mutex_lock(&ct_del_args.mutex);
-    if (ct_del_args.kind == SAVE_INPUT_IPS) {
+    if (ct_del_args.op_type == SAVE_IPS_OP) {
         ct_del_args.ips_on_host = ips_on_host;
     } else {
         ct_del_args.zones_on_host = zones_on_host;
@@ -453,7 +453,7 @@ on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
     pthread_cond_signal(&ct_del_args.clear_called_cond);
     pthread_mutex_unlock(&ct_del_args.mutex);
 
-    if (ct_del_args.kind == SAVE_INPUT_IPS) {
+    if (ct_del_args.op_type == SAVE_IPS_OP) {
         LOG(INFO, "%s: Clear completed (received %zu IPs)",
             __func__, num_entries);
     } else {

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -73,7 +73,7 @@ complete_on_load(VMState1 *object, GDBusMethodInvocation *invocation)
  *   false -> drop this entry; caller must not append it to the batch.
  */
 static bool
-apply_zone_rewrite(struct nf_conntrack *ct, struct load_targets *targets)
+apply_zone_rewrite(struct nf_conntrack *ct, const struct load_targets *targets)
 {
     uint16_t old_zone, new_zone;
     gpointer val;
@@ -153,17 +153,9 @@ static gboolean
 on_load(VMState1 *object, GDBusMethodInvocation *invocation,
         const gchar *arg_data, gpointer user_data)
 {
-    struct dbus_targs *targs;
+
+    struct dbus_targs *targs = user_data;
     GVariant *args, *var;
-
-    if (object == NULL || invocation == NULL || user_data == NULL) {
-        LOG(ERROR, "%s: NULL input (object=%p invocation=%p user_data=%p)",
-            __func__, (void *)object, (void *)invocation,
-            (void *)user_data);
-        return FALSE;
-    }
-
-    targs = user_data;
     gsize size;
     void *payload;
     uint32_t payload_size;
@@ -304,18 +296,10 @@ on_load(VMState1 *object, GDBusMethodInvocation *invocation,
 static gboolean
 on_save(VMState1 *object, GDBusMethodInvocation *invocation, gpointer user_data)
 {
-    struct dbus_targs *targs;
-    struct data_template *data_tmpl;
-
-    if (object == NULL || invocation == NULL || user_data == NULL) {
-        LOG(ERROR, "%s: NULL input (object=%p invocation=%p user_data=%p)",
-            __func__, (void *)object, (void *)invocation,
-            (void *)user_data);
-        return FALSE;
-    }
-
     LOG(INFO, "%s: Save start.", __func__);
-    targs = user_data;
+
+    struct dbus_targs *targs = user_data;
+    struct data_template *data_tmpl;
     uint32_t data_size = 0;
     void *buf;
     GVariant *child;
@@ -403,17 +387,9 @@ static gboolean
 on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
                  const gchar *arg_data, gpointer user_data)
 {
-    GVariant *args, *var;
-
-    if (object == NULL || invocation == NULL || user_data == NULL) {
-        LOG(ERROR, "%s: NULL input (object=%p invocation=%p user_data=%p)",
-            __func__, (void *)object, (void *)invocation,
-            (void *)user_data);
-        return FALSE;
-    }
-
     LOG(INFO, "%s: Clear start (kind=%s)", __func__,
         save_input_kind_to_string(ct_del_args.kind));
+    GVariant *args, *var;
     gsize num_entries = 0;
     char **payload;
     GHashTable *ips_on_host   = NULL;
@@ -503,18 +479,10 @@ static void
 on_bus_acquired(GDBusConnection *connection, const gchar *name,
                 gpointer user_data)
 {
-    struct dbus_targs *args;
-
-    if (connection == NULL || name == NULL || user_data == NULL) {
-        LOG(ERROR, "%s: NULL input (connection=%p name=%p user_data=%p)",
-            __func__, (void *)connection, (void *)name, (void *)user_data);
-        return;
-    }
-
     LOG(INFO, "%s: Acquired a message bus connection.", __func__);
 
     manager = g_dbus_object_manager_server_new(manager_export_path);
-    args = user_data;
+    struct dbus_targs *args = user_data;
     VMState1 *vmstate1_obj;
     const gchar *helper_id = args->helper_id;
     vmstate1_obj = vmstate1_skeleton_new();
@@ -567,11 +535,6 @@ static void
 on_name_acquired(GDBusConnection *connection, const gchar *name,
                  gpointer user_data)
 {
-    if (connection == NULL || name == NULL) {
-        LOG(ERROR, "%s: NULL input (connection=%p name=%p)",
-            __func__, (void *)connection, (void *)name);
-        return;
-    }
     LOG(INFO, "%s: Acquired the name %s", __func__, name);
 }
 
@@ -589,11 +552,6 @@ static void
 on_name_lost(GDBusConnection *connection, const gchar *name,
              gpointer user_data)
 {
-    if (connection == NULL || name == NULL) {
-        LOG(ERROR, "%s: NULL input (connection=%p name=%p)",
-            __func__, (void *)connection, (void *)name);
-        return;
-    }
     LOG(WARNING, "%s: Lost the name %s.", __func__, name);
 }
 
@@ -688,14 +646,8 @@ dbus_server_init(void *data)
     guint dbus_id;
     GMainLoop *local_loop;
     bool quit_early;
-    struct dbus_targs *targs;
 
-    if (data == NULL) {
-        LOG(ERROR, "%s: data is NULL", __func__);
-        return NULL;
-    }
-
-    targs = data;
+    struct dbus_targs *targs = data;
 
     // If we are operating in save mode, connect to netlink for CT programming
     if (targs->mode == LOAD_MODE) {

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -51,6 +51,64 @@ complete_on_load(VMState1 *object, GDBusMethodInvocation *invocation)
 }
 
 /**
+ * LOAD-time zone rewrite hook.
+ *
+ * For each unmarshalled CT entry, looks up its CT zone in the
+ * (old_zone -> new_zone) map and overwrites ATTR_ZONE in place. Entries
+ * whose old_zone is not in the map are dropped: the source migrated a
+ * zone that the destination wasn't told about, which is a control-plane
+ * mismatch we'd rather log than silently land in the wrong zone.
+ *
+ * Note: only ATTR_ZONE is on the wire (see ct_entry_attr_to_nf_attr in
+ * conntrack_entry.c); the kernel populates orig/repl-zone from this
+ * single value when it inserts the entry.
+ *
+ * Args:
+ *   @ct      pointer to the freshly-unmarshalled nf_conntrack object.
+ *   @targets LOAD targets bundle. NULL is treated as legacy pass-through.
+ *
+ * Returns:
+ *   true  -> proceed with this entry (rewrite applied or pass-through).
+ *   false -> drop this entry; caller must not append it to the batch.
+ */
+static bool
+apply_zone_rewrite(struct nf_conntrack *ct, struct load_targets *targets)
+{
+    uint16_t old_zone, new_zone;
+    gpointer val;
+
+    if (targets == NULL || targets->kind == LOAD_INPUT_LEGACY) {
+        return true;
+    }
+
+    /* Zone-mode LOAD: every entry must carry a CT zone. SAVE-side
+     * validate_ct_entry (Step 2) enforces this, but defend anyway so we
+     * never silently land an unzoned entry in the kernel's default zone. */
+    if (nfct_attr_is_set(ct, ATTR_ZONE) <= 0) {
+        LOG(WARNING, "%s: zone-mode LOAD received entry with no ATTR_ZONE; "
+            "dropping.", __func__);
+        return false;
+    }
+
+    old_zone = nfct_get_attr_u16(ct, ATTR_ZONE);
+
+    val = g_hash_table_lookup(targets->zone_remap,
+                              GUINT_TO_POINTER((guint) old_zone));
+    if (val == NULL) {
+        LOG(WARNING, "%s: old_zone %u not in zone_remap; dropping entry.",
+            __func__, (unsigned) old_zone);
+        return false;
+    }
+    new_zone = (uint16_t) GPOINTER_TO_UINT(val);
+
+    nfct_set_attr_u16(ct, ATTR_ZONE, new_zone);
+
+    LOG(VERBOSE, "%s: rewrote zone %u -> %u",
+        __func__, (unsigned) old_zone, (unsigned) new_zone);
+    return true;
+}
+
+/**
  * IPC endpoint for Load message.
  *
  * This function is called at the destination host where it receives the
@@ -86,6 +144,7 @@ on_load(VMState1 *object, GDBusMethodInvocation *invocation,
         const gchar *arg_data, gpointer user_data)
 {
 
+    struct dbus_targs *targs = user_data;
     GVariant *args, *var;
     gsize size;
     void *payload;
@@ -157,6 +216,14 @@ on_load(VMState1 *object, GDBusMethodInvocation *invocation,
 
         payload += bytes_read;
         total_bytes_read += bytes_read;
+
+        // Apply the LOAD-time zone rewrite (no-op in legacy mode). Entries
+        // whose source zone isn't in zone_remap are dropped here so they
+        // never reach the batch builder.
+        if (!apply_zone_rewrite(ct, targs->load_targets)) {
+            label = NULL;
+            continue;
+        }
 
         curr_batch_offset = mnl_nlmsg_batch_current(batch);
 

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -65,15 +65,16 @@ complete_on_load(VMState1 *object, GDBusMethodInvocation *invocation)
  * single value when it inserts the entry.
  *
  * Args:
- *   @ct      pointer to the freshly-unmarshalled nf_conntrack object.
- *   @targets LOAD targets bundle. NULL is treated as legacy pass-through.
+ *   @ct          pointer to the freshly-unmarshalled nf_conntrack object.
+ *   @load_config LOAD-mode config. NULL is treated as legacy pass-through.
  *
  * Returns:
  *   true  -> proceed with this entry (rewrite applied or pass-through).
  *   false -> drop this entry; caller must not append it to the batch.
  */
 static bool
-apply_zone_rewrite(struct nf_conntrack *ct, const struct load_targets *targets)
+apply_zone_rewrite(struct nf_conntrack *ct,
+                   const struct load_mode_config *load_config)
 {
     uint16_t old_zone, new_zone;
     gpointer val;
@@ -83,7 +84,7 @@ apply_zone_rewrite(struct nf_conntrack *ct, const struct load_targets *targets)
         return false;
     }
 
-    if (targets == NULL || targets->kind == LOAD_INPUT_LEGACY) {
+    if (load_config == NULL || load_config->kind == LOAD_INPUT_LEGACY) {
         return true;
     }
 
@@ -102,10 +103,10 @@ apply_zone_rewrite(struct nf_conntrack *ct, const struct load_targets *targets)
      * whose GUINT_TO_POINTER is NULL". The latter is a legitimate remap
      * to zone 0; plain g_hash_table_lookup conflates the two and would
      * silently drop a valid old_zone -> 0 mapping. */
-    if (!g_hash_table_lookup_extended(targets->zone_remap,
+    if (!g_hash_table_lookup_extended(load_config->src_dst_zone_map,
                                       GUINT_TO_POINTER((guint) old_zone),
                                       NULL, &val)) {
-        LOG(WARNING, "%s: old_zone %u not in zone_remap; dropping entry.",
+        LOG(WARNING, "%s: old_zone %u not in src_dst_zone_map; dropping entry.",
             __func__, (unsigned) old_zone);
         return false;
     }
@@ -228,9 +229,9 @@ on_load(VMState1 *object, GDBusMethodInvocation *invocation,
         total_bytes_read += bytes_read;
 
         // Apply the LOAD-time zone rewrite (no-op in legacy mode). Entries
-        // whose source zone isn't in zone_remap are dropped here so they
-        // never reach the batch builder.
-        if (!apply_zone_rewrite(ct, targs->load_targets)) {
+        // whose source zone isn't in src_dst_zone_map are dropped here so
+        // they never reach the batch builder.
+        if (!apply_zone_rewrite(ct, targs->load_config)) {
             label = NULL;
             continue;
         }

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -309,7 +309,7 @@ on_save(VMState1 *object, GDBusMethodInvocation *invocation, gpointer user_data)
     // gracefully exit.
     *(targs->stop_flag) = true;
 
-    data_tmpl = data_template_new();
+    data_tmpl = data_template_new(targs->save_kind);
 
     buf = marshal(conn_store, data_tmpl, &data_size);
     if (buf == NULL) {

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -93,9 +93,13 @@ apply_zone_rewrite(struct nf_conntrack *ct, struct load_targets *targets)
 
     old_zone = nfct_get_attr_u16(ct, ATTR_ZONE);
 
-    val = g_hash_table_lookup(targets->zone_remap,
-                              GUINT_TO_POINTER((guint) old_zone));
-    if (val == NULL) {
+    /* _extended distinguishes "key not in map" from "key maps to value
+     * whose GUINT_TO_POINTER is NULL". The latter is a legitimate remap
+     * to zone 0; plain g_hash_table_lookup conflates the two and would
+     * silently drop a valid old_zone -> 0 mapping. */
+    if (!g_hash_table_lookup_extended(targets->zone_remap,
+                                      GUINT_TO_POINTER((guint) old_zone),
+                                      NULL, &val)) {
         LOG(WARNING, "%s: old_zone %u not in zone_remap; dropping entry.",
             __func__, (unsigned) old_zone);
         return false;
@@ -228,8 +232,13 @@ on_load(VMState1 *object, GDBusMethodInvocation *invocation,
 
         curr_batch_offset = mnl_nlmsg_batch_current(batch);
 
-        // Do the programming here
-        append_ct_to_batch(curr_batch_offset, ct, label, seq++);
+        // Do the programming here. If the build failed the partial header
+        // is left in place at curr_batch_offset; skip mnl_nlmsg_batch_next
+        // so the next iteration overwrites it.
+        if (append_ct_to_batch(curr_batch_offset, ct, label, seq++) < 0) {
+            label = NULL;
+            continue;
+        }
         label = NULL;
         // If there is space in batch, add the entry to it
         if (mnl_nlmsg_batch_next(batch)) {
@@ -593,6 +602,26 @@ err:
 }
 
 /**
+ * Asks the dbus thread to exit its main loop gracefully.
+ *
+ * See declaration in dbus_server.h for the full contract.
+ */
+void
+dbus_server_request_quit(struct dbus_targs *targs)
+{
+    if (targs == NULL) {
+        return;
+    }
+
+    pthread_mutex_lock(&targs->loop_mu);
+    targs->should_quit = true;
+    if (targs->loop != NULL) {
+        g_main_loop_quit(targs->loop);
+    }
+    pthread_mutex_unlock(&targs->loop_mu);
+}
+
+/**
  * Starts the dbus server.
  *
  * This function performs the following tasks:
@@ -610,6 +639,8 @@ void *
 dbus_server_init(void *data)
 {
     guint dbus_id;
+    GMainLoop *local_loop;
+    bool quit_early;
 
     struct dbus_targs *targs = data;
 
@@ -626,7 +657,30 @@ dbus_server_init(void *data)
                 "programming", __func__);
         }
     }
-    loop = g_main_loop_new(NULL, FALSE);
+
+    /* Publish the loop atomically with the should_quit check so any quit
+     * request that arrived while we were still booting is honoured before
+     * we ever enter g_main_loop_run. Mirroring to the file-static `loop`
+     * keeps complete_on_load / complete_on_clear working unchanged. */
+    local_loop = g_main_loop_new(NULL, FALSE);
+    pthread_mutex_lock(&targs->loop_mu);
+    targs->loop = local_loop;
+    loop = local_loop;
+    quit_early = targs->should_quit;
+    pthread_mutex_unlock(&targs->loop_mu);
+
+    if (quit_early) {
+        LOG(INFO, "%s: shutdown requested before loop start; exiting.",
+            __func__);
+        pthread_mutex_lock(&targs->loop_mu);
+        targs->loop = NULL;
+        loop = NULL;
+        pthread_mutex_unlock(&targs->loop_mu);
+        g_main_loop_unref(local_loop);
+        *(targs->stop_flag) = true;
+        return NULL;
+    }
+
     dbus_id = g_bus_own_name(G_BUS_TYPE_SYSTEM,
                              dbus_name,
                              G_BUS_NAME_OWNER_FLAGS_NONE,
@@ -636,9 +690,14 @@ dbus_server_init(void *data)
                              data,
                              NULL);
 
-    g_main_loop_run(loop);
+    g_main_loop_run(local_loop);
     g_bus_unown_name(dbus_id);
-    g_main_loop_unref(loop);
+
+    pthread_mutex_lock(&targs->loop_mu);
+    targs->loop = NULL;
+    loop = NULL;
+    pthread_mutex_unlock(&targs->loop_mu);
+    g_main_loop_unref(local_loop);
 
     // Set the boolean flag to true, so that netlink threads can
     // gracefully exit

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -12,6 +12,7 @@
  */
 
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -338,9 +339,14 @@ complete_on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation)
  *
  *   - IP mode  (SAVE_INPUT_IPS)        : each string is an IPv4 address
  *                                        currently present on this host.
- *   - Zone mode (SAVE_INPUT_PORT_ZONES): each string is a decimal CT zone
- *                                        currently owned by a port still
- *                                        on this host.
+ *   - Zone mode (SAVE_INPUT_PORT_ZONES): a flat strv of paired entries
+ *                                        [port_uuid_0, zone_0,
+ *                                         port_uuid_1, zone_1, ...] where
+ *                                        each zone is a decimal CT zone
+ *                                        currently owned by the named
+ *                                        port still on this host. Length
+ *                                        must be even; the helper only
+ *                                        retains the zone half.
  *
  * On success the parsed set is published to ct_del_args under the lock,
  * the clear_called condition is signalled, and the delete thread wakes
@@ -380,13 +386,37 @@ on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
     var = g_variant_get_child_value(args, 0);
     payload = g_variant_dup_strv(var, &num_entries);
 
+    /* Both downstream parsers take an int. g_variant_dup_strv reports a
+     * gsize, so guard against a (theoretical) D-Bus payload that would
+     * silently narrow to a negative or truncated int on the call below.
+     * In practice num_entries is tiny, but failing fast at the IPC
+     * boundary is cheaper than reasoning about it later. */
+    if (num_entries > INT_MAX) {
+        LOG(ERROR, "%s: clear payload too large for int (%zu entries)",
+            __func__, num_entries);
+        g_strfreev(payload);
+        return complete_on_clear(object, invocation);
+    }
+
+    /* Zone-mode clear payload is paired (port_uuid, zone). Catch a
+     * malformed odd-length strv up front so the parser doesn't have to
+     * own this protocol-level invariant on its own. */
+    if (ct_del_args.kind == SAVE_INPUT_PORT_ZONES &&
+        (num_entries % 2) != 0) {
+        LOG(ERROR, "%s: zone-mode clear payload must be paired "
+            "(port_uuid, zone); got odd length %zu",
+            __func__, num_entries);
+        g_strfreev(payload);
+        return complete_on_clear(object, invocation);
+    }
+
     if (ct_del_args.kind == SAVE_INPUT_IPS) {
         ips_on_host = create_hashtable_from_ip_list(
-                          (const char **)payload, num_entries);
+                          (const char **)payload, (int) num_entries);
         parse_ok = (ips_on_host != NULL);
     } else {   /* SAVE_INPUT_PORT_ZONES */
-        zones_on_host = create_hashtable_from_zone_str_list(
-                            (const char **)payload, num_entries);
+        zones_on_host = create_hashtable_from_port_zone_pairs(
+                            (const char **)payload, (int) num_entries);
         parse_ok = (zones_on_host != NULL);
     }
     g_strfreev(payload);
@@ -408,8 +438,13 @@ on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
     pthread_cond_signal(&ct_del_args.clear_called_cond);
     pthread_mutex_unlock(&ct_del_args.mutex);
 
-    LOG(INFO, "%s: Clear completed (received %zu %s)", __func__, num_entries,
-        ct_del_args.kind == SAVE_INPUT_IPS ? "IPs" : "zones");
+    if (ct_del_args.kind == SAVE_INPUT_IPS) {
+        LOG(INFO, "%s: Clear completed (received %zu IPs)",
+            __func__, num_entries);
+    } else {
+        LOG(INFO, "%s: Clear completed (received %zu port/zone pairs)",
+            __func__, num_entries / 2);
+    }
     return complete_on_clear(object, invocation);
 }
 

--- a/src/dbus_server.c
+++ b/src/dbus_server.c
@@ -78,6 +78,11 @@ apply_zone_rewrite(struct nf_conntrack *ct, struct load_targets *targets)
     uint16_t old_zone, new_zone;
     gpointer val;
 
+    if (ct == NULL) {
+        LOG(ERROR, "%s: ct is NULL", __func__);
+        return false;
+    }
+
     if (targets == NULL || targets->kind == LOAD_INPUT_LEGACY) {
         return true;
     }
@@ -148,9 +153,17 @@ static gboolean
 on_load(VMState1 *object, GDBusMethodInvocation *invocation,
         const gchar *arg_data, gpointer user_data)
 {
-
-    struct dbus_targs *targs = user_data;
+    struct dbus_targs *targs;
     GVariant *args, *var;
+
+    if (object == NULL || invocation == NULL || user_data == NULL) {
+        LOG(ERROR, "%s: NULL input (object=%p invocation=%p user_data=%p)",
+            __func__, (void *)object, (void *)invocation,
+            (void *)user_data);
+        return FALSE;
+    }
+
+    targs = user_data;
     gsize size;
     void *payload;
     uint32_t payload_size;
@@ -291,10 +304,18 @@ on_load(VMState1 *object, GDBusMethodInvocation *invocation,
 static gboolean
 on_save(VMState1 *object, GDBusMethodInvocation *invocation, gpointer user_data)
 {
-    LOG(INFO, "%s: Save start.", __func__);
-
-    struct dbus_targs *targs = user_data;
+    struct dbus_targs *targs;
     struct data_template *data_tmpl;
+
+    if (object == NULL || invocation == NULL || user_data == NULL) {
+        LOG(ERROR, "%s: NULL input (object=%p invocation=%p user_data=%p)",
+            __func__, (void *)object, (void *)invocation,
+            (void *)user_data);
+        return FALSE;
+    }
+
+    LOG(INFO, "%s: Save start.", __func__);
+    targs = user_data;
     uint32_t data_size = 0;
     void *buf;
     GVariant *child;
@@ -382,9 +403,17 @@ static gboolean
 on_clear(LmctMgmt *object, GDBusMethodInvocation *invocation,
                  const gchar *arg_data, gpointer user_data)
 {
+    GVariant *args, *var;
+
+    if (object == NULL || invocation == NULL || user_data == NULL) {
+        LOG(ERROR, "%s: NULL input (object=%p invocation=%p user_data=%p)",
+            __func__, (void *)object, (void *)invocation,
+            (void *)user_data);
+        return FALSE;
+    }
+
     LOG(INFO, "%s: Clear start (kind=%s)", __func__,
         save_input_kind_to_string(ct_del_args.kind));
-    GVariant *args, *var;
     gsize num_entries = 0;
     char **payload;
     GHashTable *ips_on_host   = NULL;
@@ -474,10 +503,18 @@ static void
 on_bus_acquired(GDBusConnection *connection, const gchar *name,
                 gpointer user_data)
 {
+    struct dbus_targs *args;
+
+    if (connection == NULL || name == NULL || user_data == NULL) {
+        LOG(ERROR, "%s: NULL input (connection=%p name=%p user_data=%p)",
+            __func__, (void *)connection, (void *)name, (void *)user_data);
+        return;
+    }
+
     LOG(INFO, "%s: Acquired a message bus connection.", __func__);
 
     manager = g_dbus_object_manager_server_new(manager_export_path);
-    struct dbus_targs *args = user_data;
+    args = user_data;
     VMState1 *vmstate1_obj;
     const gchar *helper_id = args->helper_id;
     vmstate1_obj = vmstate1_skeleton_new();
@@ -530,6 +567,11 @@ static void
 on_name_acquired(GDBusConnection *connection, const gchar *name,
                  gpointer user_data)
 {
+    if (connection == NULL || name == NULL) {
+        LOG(ERROR, "%s: NULL input (connection=%p name=%p)",
+            __func__, (void *)connection, (void *)name);
+        return;
+    }
     LOG(INFO, "%s: Acquired the name %s", __func__, name);
 }
 
@@ -547,6 +589,11 @@ static void
 on_name_lost(GDBusConnection *connection, const gchar *name,
              gpointer user_data)
 {
+    if (connection == NULL || name == NULL) {
+        LOG(ERROR, "%s: NULL input (connection=%p name=%p)",
+            __func__, (void *)connection, (void *)name);
+        return;
+    }
     LOG(WARNING, "%s: Lost the name %s.", __func__, name);
 }
 
@@ -641,8 +688,14 @@ dbus_server_init(void *data)
     guint dbus_id;
     GMainLoop *local_loop;
     bool quit_early;
+    struct dbus_targs *targs;
 
-    struct dbus_targs *targs = data;
+    if (data == NULL) {
+        LOG(ERROR, "%s: data is NULL", __func__);
+        return NULL;
+    }
+
+    targs = data;
 
     // If we are operating in save mode, connect to netlink for CT programming
     if (targs->mode == LOAD_MODE) {

--- a/src/main.c
+++ b/src/main.c
@@ -591,17 +591,23 @@ dmain(int argc, char *argv[])
     int mode;
     const char *helper_id;
     int ret;
+    int rc = 0;
     bool stop_flag = false;
-    struct dbus_targs dbus_server_args;
+    bool log_open = false;
+    bool dbus_started = false;
+    bool loop_mu_inited = false;
+    struct dbus_targs dbus_server_args = {0};
+    struct save_targets *save_targets = NULL;
     enum save_input_kind save_kind = SAVE_INPUT_IPS;
 
     // Parse the command line arguments.
     mode = atoi(argv[MODE_ARG_INDEX]);
     helper_id = argv[HELPER_ID_ARG_INDEX];
 
-    // Re-detect the SAVE sub-kind here because the parent's parsed_cli
-    // lived on a stack frame that is gone after the double fork. argv
-    // is preserved across forks, so detection is cheap and side-effect-free.
+    // Re-detect the SAVE sub-kind here because we don't currently thread
+    // the parent's parsed_cli through the double fork (CR5 will fix
+    // that). argv is preserved across forks, so detection is cheap and
+    // side-effect-free.
     if (mode == SAVE_MODE) {
         save_kind = detect_save_input_kind(argc, argv);
     }
@@ -609,8 +615,9 @@ dmain(int argc, char *argv[])
     // Initialise logging at default INFO level.
     ret = init_log(INFO, helper_id);
     if (ret != 0) {
-        return EAGAIN;
+        return EAGAIN;   // nothing else allocated yet
     }
+    log_open = true;
 
     // Init configs.
     init_lmct_config(lmct_config_path);
@@ -629,7 +636,8 @@ dmain(int argc, char *argv[])
     conn_store = conntrack_store_new();
     if (conn_store == NULL) {
         LOG(ERROR, "%s: connection_store is NULL", __func__);
-        return EAGAIN;
+        rc = EAGAIN;
+        goto cleanup;
     }
 
     // Start the dbus server
@@ -637,6 +645,15 @@ dmain(int argc, char *argv[])
     dbus_server_args.stop_flag    = &stop_flag;
     dbus_server_args.mode         = (enum op_mode) mode;
     dbus_server_args.load_targets = NULL;
+    dbus_server_args.loop         = NULL;
+    dbus_server_args.should_quit  = false;
+    ret = pthread_mutex_init(&dbus_server_args.loop_mu, NULL);
+    if (ret != 0) {
+        LOG(ERROR, "%s: failed to init loop_mu: %s", __func__, strerror(ret));
+        rc = EAGAIN;
+        goto cleanup;
+    }
+    loop_mu_inited = true;
 
     /* In LOAD mode build the (old_zone -> new_zone) remap up-front so the
      * dbus thread has it ready by the time the destination's Load IPC
@@ -655,7 +672,8 @@ dmain(int argc, char *argv[])
                                                 LOAD_PORT_ZONE_STRIDE);
             if (dbus_server_args.load_targets == NULL) {
                 LOG(ERROR, "%s: failed to build load_targets", __func__);
-                return EINVAL;
+                rc = EINVAL;
+                goto cleanup;
             }
             LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
                 __func__, n);
@@ -668,8 +686,10 @@ dmain(int argc, char *argv[])
     if (ret != 0) {
         LOG(ERROR, "%s: dbus_server thread creation failed. %s", __func__,
             strerror(ret));
-        return EAGAIN;
+        rc = EAGAIN;
+        goto cleanup;
     }
+    dbus_started = true;
     ret = pthread_setname_np(dbus_server_args.tid, "dbus_server");
     if (ret != 0) {
         LOG(WARNING, "%s: Failed to set thread name \"dbus_server\". %s",
@@ -678,39 +698,74 @@ dmain(int argc, char *argv[])
 
     // Start save mode threads.
     if (mode == SAVE_MODE) {
-        struct save_targets *targets;
-
         if (save_kind == SAVE_INPUT_IPS) {
             GHashTable *ips_to_migrate;
             ips_to_migrate = create_ips_ht_from_args(argv);
             if (ips_to_migrate == NULL) {
-                return EINVAL;
+                rc = EINVAL;
+                goto cleanup;
             }
-            targets = save_targets_new_from_ips(ips_to_migrate);
+            save_targets = save_targets_new_from_ips(ips_to_migrate);
         } else {
             GHashTable *zones_ht = NULL;
             GHashTable *ports_ht = NULL;
             zones_ht = create_zones_and_port_ht_from_args(argv, &ports_ht);
             if (zones_ht == NULL) {
-                return EINVAL;
+                rc = EINVAL;
+                goto cleanup;
             }
-            targets = save_targets_new_from_zones_and_ports(zones_ht,
-                                                            ports_ht);
+            save_targets = save_targets_new_from_zones_and_ports(zones_ht,
+                                                                 ports_ht);
         }
 
-        ret = start_in_save_mode(targets, &stop_flag);
-        save_targets_destroy(targets);
+        ret = start_in_save_mode(save_targets, &stop_flag);
         if (ret != 0) {
-            return EAGAIN;
+            rc = EAGAIN;
+            /* start_in_save_mode may have left events threads running
+             * that still reference save_targets (a pre-existing issue
+             * tracked separately). Don't destroy save_targets in that
+             * case -- a small intentional leak on the abnormal-exit
+             * path is preferable to a use-after-free. */
+            save_targets = NULL;
         }
     }
 
-    pthread_join(dbus_server_args.tid, NULL);
-    conntrack_store_destroy(conn_store);
-    load_targets_destroy(dbus_server_args.load_targets);
-    close_log();
+cleanup:
+    /* Tell any still-running events threads to exit. start_in_save_mode
+     * normally joins them itself, but we set this defensively to cover
+     * partial-failure paths that leave the events threads alive. */
+    stop_flag = true;
 
-    return 0;
+    /* Wake the dbus thread on every error path so pthread_join below
+     * doesn't hang waiting for an RPC that will never arrive. On the
+     * normal success path the loop has already quit itself (via
+     * on_save -> ... -> on_clear -> g_main_loop_quit for SAVE, and
+     * on_load -> g_main_loop_quit for LOAD), so request_quit is a no-op
+     * there. */
+    if (dbus_started) {
+        if (rc != 0) {
+            dbus_server_request_quit(&dbus_server_args);
+        }
+        pthread_join(dbus_server_args.tid, NULL);
+    }
+    if (save_targets != NULL) {
+        save_targets_destroy(save_targets);
+    }
+    if (dbus_server_args.load_targets != NULL) {
+        load_targets_destroy(dbus_server_args.load_targets);
+    }
+    if (loop_mu_inited) {
+        pthread_mutex_destroy(&dbus_server_args.loop_mu);
+    }
+    if (conn_store != NULL) {
+        conntrack_store_destroy(conn_store);
+        conn_store = NULL;
+    }
+    if (log_open) {
+        close_log();
+    }
+
+    return rc;
 }
 
 static void

--- a/src/main.c
+++ b/src/main.c
@@ -81,28 +81,7 @@
 #define SAVE_PORT_ZONE_STRIDE           2   /* <port_uuid> <old_ct_zone> */
 #define LOAD_PORT_ZONE_STRIDE           3   /* <port_uuid> <old_ct_zone> <new_ct_zone> */
 
-/* Canonical UUID hex string length: 8-4-4-4-12 = 36 chars. */
-#define UUID_STRING_LEN                 36
-
 #define MAX_IP_ADDRESSES_SUPPORTED      127
-
-/**
- * Sub-mode tag: tells the rest of the daemon which SAVE-mode CLI layout
- * was detected from argv.
- */
-enum save_input_kind {
-    SAVE_INPUT_IPS,
-    SAVE_INPUT_PORT_ZONES
-};
-
-/**
- * Sub-mode tag: tells the rest of the daemon which LOAD-mode CLI layout
- * was detected from argv.
- */
-enum load_input_kind {
-    LOAD_INPUT_LEGACY,
-    LOAD_INPUT_PORT_ZONES
-};
 
 /**
  * Result of CLI parsing - filled by check_args() and consumed by main().
@@ -170,7 +149,7 @@ pthread_wrapper_ct_events(void *data)
         return NULL;
     }
 
-    listen_for_conntrack_events(nl, targs->ips_to_migrate,
+    listen_for_conntrack_events(nl, targs->targets,
                                 targs->is_src, targs->stop_flag);
     mnl_socket_close(nl);
 
@@ -181,14 +160,15 @@ pthread_wrapper_ct_events(void *data)
 }
 
 /**
- * Gets all the entries present in the kernel CT table for the given IP
- * addresses.
+ * Gets all the entries present in the kernel CT table for the given
+ * SAVE migration targets.
  *
  * Args:
- *   @ips_to_migrate IP addresses used to filter the required CT entries.
+ *   @targets SAVE targets bundle (mode-aware) used to filter the required
+ *            CT entries.
  */
 static void
-dump_conntrack(GHashTable *ips_to_migrate)
+dump_conntrack(struct save_targets *targets)
 {
     struct nfct_handle *handle;
 
@@ -199,7 +179,7 @@ dump_conntrack(GHashTable *ips_to_migrate)
         LOG(ERROR, "%s: nfct_open failed. %s", __func__, strerror(errno));
         return;
     }
-    get_conntrack_dump(handle, ips_to_migrate);
+    get_conntrack_dump(handle, targets);
     nfct_close(handle);
 }
 
@@ -207,123 +187,177 @@ dump_conntrack(GHashTable *ips_to_migrate)
  * Start threads required for save mode of operation.
  *
  * Following things are performed in the save mode:
- * 1. Conntrack delete thread is started which waits till Clear IPC is called.
- * 2. Conntrack events threads are started to filter events for the IP
- *    addresses present in the ips_to_migrate. If any update is received for a
- *    non-exisitent entry, it is treated as NEW since it contains the base five
- *    tuple information required to identify flow. Similarly, if a destroy
- *    event is received for a non-existent entry, it is ignored.
+ * 1. (IP mode only) Conntrack delete thread is started which waits till
+ *    Clear IPC is called.
+ * 2. Conntrack events threads are started to filter events for the
+ *    migration targets. In IP mode this is two BPF-filtered threads
+ *    (one src, one dst). In zone mode BPF can't filter on CT zone, so a
+ *    single unfiltered thread is started and the callback does the zone
+ *    match in-process.
+ *    If any update is received for a non-exisitent entry, it is treated
+ *    as NEW since it contains the base five tuple information required to
+ *    identify flow. Similarly, if a destroy event is received for a
+ *    non-existent entry, it is ignored.
  * 3. Finally, Conntrack dump is taken from the kernel to get all the live
  *    flows in the system.
  *
  * The above workflow is used to maintain a local copy of the CT entries for
  * the VM.
  *
+ * NOTE: zone-mode cleanup (Clear/delete) is deferred to Step 3; the zone
+ * branch deliberately does not start the delete thread.
+ *
  * Args:
- *   @ips_to_migrate Hashtable of IP addresses for which CT entries
- *                   have to be migrated.
+ *   @targets SAVE targets bundle (mode-aware) for which CT entries have
+ *            to be migrated.
  *   @stop_flag flag used by thread to exit after dbus operations.
  *
  * Returns:
  *   0 in case of success, -1 otherwise
  */
 static int
-start_in_save_mode(GHashTable *ips_to_migrate, bool *stop_flag)
+start_in_save_mode(struct save_targets *targets, bool *stop_flag)
 {
     int ret;
-    uint32_t num_ips;
-    struct ct_events_targs *src_targs, *dst_targs;
+    struct ct_events_targs *src_targs, *dst_targs, *zone_targs;
 
-    // Start the delete thread.
-    // NOTE: ct_del_args is an extern global variable
-    ct_del_args.ips_migrated = ips_to_migrate;
+    if (targets->kind == SAVE_INPUT_IPS) {
+        uint32_t num_ips;
 
-    num_ips = g_hash_table_size(ips_to_migrate);
+        // Start the delete thread.
+        // NOTE: ct_del_args is an extern global variable
+        ct_del_args.ips_migrated = targets->ips_to_migrate;
 
-    // This happens in case a VM has no IPv4 NICs attached to it. Thus, the VM
-    // will not have any CT entries present in kernel to migrate. Also, since
-    // QEMU expects helper process to be present during migration, we do not
-    // exit the process completely rather just runs the dbus server to
-    // facilitate the IPC calls.
-    if (num_ips == 0) {
-        LOG(INFO, "%s: Not starting any save mode threads since number of IP "
-            "addresses is 0", __func__);
+        num_ips = g_hash_table_size(targets->ips_to_migrate);
+
+        // This happens in case a VM has no IPv4 NICs attached to it. Thus,
+        // the VM will not have any CT entries present in kernel to migrate.
+        // Also, since QEMU expects helper process to be present during
+        // migration, we do not exit the process completely rather just runs
+        // the dbus server to facilitate the IPC calls.
+        if (num_ips == 0) {
+            LOG(INFO, "%s: Not starting any save mode threads since number "
+                "of IP addresses is 0", __func__);
+            return 0;
+        }
+
+        if (num_ips > MAX_IP_ADDRESSES_SUPPORTED) {
+            LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
+                "No Conntrack Migration will be performed.",
+                MAX_IP_ADDRESSES_SUPPORTED);
+            return 0;
+        }
+
+        // Conntrack delete thread.
+        ret = pthread_create(&ct_del_args.tid, NULL,
+                             &delete_ct_entries,
+                             (void *)&ct_del_args);
+        if (ret != 0) {
+            LOG(ERROR, "%s: CT delete thread creation failed. %s", __func__,
+                strerror(ret));
+            return -1;
+        }
+        ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
+        if (ret != 0) {
+            LOG(WARNING, "%s: Failed to set thread name \"ct_delete\": %s",
+                __func__, strerror(ret));
+        }
+
+        // Listen for conntrack events which contains their src IP address
+        // in ips_to_migrate.
+        src_targs = g_malloc0(sizeof(struct ct_events_targs));
+        src_targs->targets = targets;
+        src_targs->stop_flag = stop_flag;
+        src_targs->is_src = true;
+        ret = pthread_create(&src_targs->tid, NULL, &pthread_wrapper_ct_events,
+                             (void *)src_targs);
+        if (ret != 0) {
+            LOG(ERROR, "%s: src events thread creation failed. %s", __func__,
+                strerror(ret));
+            return -1;
+        }
+        ret = pthread_setname_np(src_targs->tid, "ct_events_src");
+        if (ret != 0) {
+            LOG(WARNING, "%s: Failed to set thread name \"ct_events_src\". %s",
+                __func__, strerror(ret));
+        }
+
+        // Listen for conntrack events which contains their dst IP address
+        // in ips_to_migrate.
+        dst_targs = g_malloc0(sizeof(struct ct_events_targs));
+        dst_targs->targets = targets;
+        dst_targs->stop_flag = stop_flag;
+        dst_targs->is_src = false;
+        ret = pthread_create(&dst_targs->tid, NULL,
+                             &pthread_wrapper_ct_events,
+                             (void *)dst_targs);
+        if (ret != 0) {
+            LOG(ERROR, "%s: dst events thread creation failed. %s", __func__,
+                strerror(ret));
+            return -1;
+        }
+        ret = pthread_setname_np(dst_targs->tid, "ct_events_dst");
+        if (ret != 0) {
+            LOG(WARNING, "%s: Failed to set thread name \"ct_events_dst\". %s",
+                __func__, strerror(ret));
+        }
+
+        // Get all the conntrack entries for the given ip address.
+        dump_conntrack(targets);
+
+        // Wait for all the threads to be stopped.
+        pthread_join(src_targs->tid, NULL);
+        pthread_join(dst_targs->tid, NULL);
+        pthread_join(ct_del_args.tid, NULL);
+
+        g_free(src_targs);
+        g_free(dst_targs);
+
         return 0;
     }
 
-    if (num_ips > MAX_IP_ADDRESSES_SUPPORTED) {
-        LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
-            "No Conntrack Migration will be performed.",
-            MAX_IP_ADDRESSES_SUPPORTED);
+    /* SAVE_INPUT_PORT_ZONES */
+    {
+        uint32_t num_zones = g_hash_table_size(targets->zones_to_migrate);
+
+        if (num_zones == 0) {
+            LOG(INFO, "%s: Not starting any save mode threads since number "
+                "of zones is 0", __func__);
+            return 0;
+        }
+
+        // BPF can't filter on CT zone, so we don't split src/dst threads.
+        // One unfiltered events thread is enough; the callback does the
+        // zone match in-process.
+        zone_targs = g_malloc0(sizeof(struct ct_events_targs));
+        zone_targs->targets = targets;
+        zone_targs->stop_flag = stop_flag;
+        zone_targs->is_src = false;   /* unused in zone mode */
+        ret = pthread_create(&zone_targs->tid, NULL,
+                             &pthread_wrapper_ct_events,
+                             (void *)zone_targs);
+        if (ret != 0) {
+            LOG(ERROR, "%s: zone events thread creation failed. %s", __func__,
+                strerror(ret));
+            return -1;
+        }
+        ret = pthread_setname_np(zone_targs->tid, "ct_events_zone");
+        if (ret != 0) {
+            LOG(WARNING, "%s: Failed to set thread name \"ct_events_zone\". "
+                "%s", __func__, strerror(ret));
+        }
+
+        // Get all the conntrack entries for the given zones.
+        dump_conntrack(targets);
+
+        // Wait for the events thread to be stopped. Zone-mode cleanup
+        // (Clear/delete) is deferred to Step 3; no delete thread to join.
+        pthread_join(zone_targs->tid, NULL);
+
+        g_free(zone_targs);
+
         return 0;
     }
-
-    // Conntrack delete thread.
-    ret = pthread_create(&ct_del_args.tid, NULL,
-                         &delete_ct_entries,
-                         (void *)&ct_del_args);
-    if (ret != 0) {
-        LOG(ERROR, "%s: CT delete thread creation failed. %s", __func__,
-            strerror(ret));
-        return -1;
-    }
-    ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
-    if (ret != 0) {
-        LOG(WARNING, "%s: Failed to set thread name \"ct_delete\": %s",
-            __func__, strerror(ret));
-    }
-
-    // Listen for conntrack events which contains their src IP address
-    // in ips_to_migrate.
-    src_targs = g_malloc0(sizeof(struct ct_events_targs));
-    src_targs->ips_to_migrate = ips_to_migrate;
-    src_targs->stop_flag = stop_flag;
-    src_targs->is_src = true;
-    ret = pthread_create(&src_targs->tid, NULL, &pthread_wrapper_ct_events,
-                         (void *)src_targs);
-    if (ret != 0) {
-        LOG(ERROR, "%s: src events thread creation failed. %s", __func__,
-            strerror(ret));
-        return -1;
-    }
-    ret = pthread_setname_np(src_targs->tid, "ct_events_src");
-    if (ret != 0) {
-        LOG(WARNING, "%s: Failed to set thread name \"ct_events_src\". %s",
-            __func__, strerror(ret));
-    }
-
-    // Listen for conntrack events which contains their dst IP address
-    // in ips_to_migrate.
-    dst_targs = g_malloc0(sizeof(struct ct_events_targs));
-    dst_targs->ips_to_migrate = ips_to_migrate;
-    dst_targs->stop_flag = stop_flag;
-    dst_targs->is_src = false;
-    ret = pthread_create(&dst_targs->tid, NULL,
-                         &pthread_wrapper_ct_events,
-                         (void *)dst_targs);
-    if (ret != 0) {
-        LOG(ERROR, "%s: dst events thread creation failed. %s", __func__,
-            strerror(ret));
-        return -1;
-    }
-    ret = pthread_setname_np(dst_targs->tid, "ct_events_dst");
-    if (ret != 0) {
-        LOG(WARNING, "%s: Failed to set thread name \"ct_events_dst\". %s",
-            __func__, strerror(ret));
-    }
-
-    // Get all the conntrack entries for the given ip address.
-    dump_conntrack(ips_to_migrate);
-
-    // Wait for all the threads to be stopped.
-    pthread_join(src_targs->tid, NULL);
-    pthread_join(dst_targs->tid, NULL);
-    pthread_join(ct_del_args.tid, NULL);
-
-    g_free(src_targs);
-    g_free(dst_targs);
-
-    return 0;
 }
 
 /**
@@ -350,6 +384,52 @@ create_ips_ht_from_args(char *argv[])
         return NULL;
     }
 
+    return ht;
+}
+
+/**
+ * Creates the (zones_to_migrate, ports_to_migrate) hashtable pair from the
+ * SAVE port-zone CLI arguments.
+ *
+ * Walks argv at the SAVE_PORT_ZONE_STRIDE-strided offsets, splits out the
+ * port_uuid and old_ct_zone columns, and hands the parallel arrays to
+ * create_hashtable_from_zone_and_port_list().
+ *
+ * Args:
+ *   @argv      array of CLI args.
+ *   @out_ports output: ports_to_migrate hashtable.
+ *
+ * Returns:
+ *   zones_to_migrate hashtable on success, NULL on failure (in which case
+ *   *out_ports is left set to NULL).
+ */
+static GHashTable *
+create_zones_and_port_ht_from_args(char *argv[], GHashTable **out_ports)
+{
+    int n_entries;
+    int i;
+    const char **zones;
+    const char **port_uuids;
+    GHashTable *ht;
+
+    n_entries = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    zones = g_malloc0(sizeof(*zones) * n_entries);
+    port_uuids = g_malloc0(sizeof(*port_uuids) * n_entries);
+    for (i = 0; i < n_entries; i++) {
+        int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
+        port_uuids[i] = argv[base];
+        zones[i] = argv[base + 1];
+    }
+
+    ht = create_hashtable_from_zone_and_port_list(zones, port_uuids,
+                                                  n_entries, out_ports);
+    g_free(zones);
+    g_free(port_uuids);
+
+    if (ht == NULL) {
+        LOG(ERROR, "%s: Hashtable creation failed.", __func__);
+        return NULL;
+    }
     return ht;
 }
 
@@ -486,24 +566,30 @@ dmain(int argc, char *argv[])
 
     // Start save mode threads.
     if (mode == SAVE_MODE) {
+        struct save_targets *targets;
+
         if (save_kind == SAVE_INPUT_IPS) {
             GHashTable *ips_to_migrate;
             ips_to_migrate = create_ips_ht_from_args(argv);
             if (ips_to_migrate == NULL) {
                 return EINVAL;
             }
-
-            ret = start_in_save_mode(ips_to_migrate, &stop_flag);
-            g_hash_table_destroy(ips_to_migrate);
-            if (ret != 0) {
-                return EAGAIN;
-            }
+            targets = save_targets_new_from_ips(ips_to_migrate);
         } else {
-            // PORT_ZONES SAVE path. Wired up in Step 2: it will build a
-            // (zones_to_migrate, ports_to_migrate) bundle from argv and
-            // hand it to a zone-aware start_in_save_mode().
-            LOG(INFO, "%s: PORT_ZONES SAVE path - "
-                "to be implemented in Step 2", __func__);
+            GHashTable *zones_ht = NULL;
+            GHashTable *ports_ht = NULL;
+            zones_ht = create_zones_and_port_ht_from_args(argv, &ports_ht);
+            if (zones_ht == NULL) {
+                return EINVAL;
+            }
+            targets = save_targets_new_from_zones_and_ports(zones_ht,
+                                                            ports_ht);
+        }
+
+        ret = start_in_save_mode(targets, &stop_flag);
+        save_targets_destroy(targets);
+        if (ret != 0) {
+            return EAGAIN;
         }
     }
 
@@ -512,81 +598,6 @@ dmain(int argc, char *argv[])
     close_log();
 
     return 0;
-}
-
-/**
- * Validates that @s is a canonical 8-4-4-4-12 hex UUID string.
- *
- * No version/variant bit checks - any 36-char hex-with-hyphens string
- * is accepted. This is intentionally permissive: callers (e.g. libvirt)
- * pass UUIDs in canonical form and we only need to reject obvious junk.
- *
- * Args:
- *   @s nul-terminated candidate string. May be NULL.
- *
- * Returns:
- *   true if the string is well-formed, false otherwise.
- */
-static bool
-is_valid_uuid_string(const char *s)
-{
-    int i;
-
-    if (s == NULL || strlen(s) != UUID_STRING_LEN) {
-        return false;
-    }
-
-    for (i = 0; i < UUID_STRING_LEN; i++) {
-        char c = s[i];
-
-        if (i == 8 || i == 13 || i == 18 || i == 23) {
-            if (c != '-') {
-                return false;
-            }
-        } else {
-            bool is_hex = (c >= '0' && c <= '9') ||
-                          (c >= 'a' && c <= 'f') ||
-                          (c >= 'A' && c <= 'F');
-            if (!is_hex) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-/**
- * Strict parser for a CT zone: must be a complete decimal uint16 with no
- * trailing junk, no whitespace, no overflow.
- *
- * Uses the standard out-parameter pattern: @out is only written on success.
- * On failure the caller's storage is left untouched.
- *
- * Args:
- *   @s   nul-terminated decimal string.
- *   @out output uint16_t (only written on success). Must be non-NULL.
- *
- * Returns:
- *   true on success, false otherwise.
- */
-static bool
-parse_ct_zone(const char *s, uint16_t *out)
-{
-    char *end = NULL;
-    unsigned long v;
-
-    if (s == NULL || *s == '\0' || out == NULL) {
-        return false;
-    }
-
-    errno = 0;
-    v = strtoul(s, &end, 10);
-    if (errno != 0 || end == s || *end != '\0' || v > UINT16_MAX) {
-        return false;
-    }
-
-    *out = (uint16_t) v;
-    return true;
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -106,8 +106,11 @@ const char *mode_to_string[] = {
 };
 
 struct ct_delete_args ct_del_args = {
+    .kind = SAVE_INPUT_IPS,       /* overwritten in start_in_save_mode */
     .ips_migrated = NULL,
     .ips_on_host = NULL,
+    .zones_migrated = NULL,
+    .zones_on_host = NULL,
     .clear_called = false,
     .mutex = PTHREAD_MUTEX_INITIALIZER,
     .clear_called_cond = PTHREAD_COND_INITIALIZER
@@ -187,14 +190,15 @@ dump_conntrack(struct save_targets *targets)
  * Start threads required for save mode of operation.
  *
  * Following things are performed in the save mode:
- * 1. (IP mode only) Conntrack delete thread is started which waits till
- *    Clear IPC is called.
+ * 1. Conntrack delete thread is started which waits till Clear IPC is
+ *    called. The thread is started in both IP and zone sub-modes; it
+ *    dispatches on ct_del_args.kind when it wakes up.
  * 2. Conntrack events threads are started to filter events for the
  *    migration targets. In IP mode this is two BPF-filtered threads
  *    (one src, one dst). In zone mode BPF can't filter on CT zone, so a
  *    single unfiltered thread is started and the callback does the zone
  *    match in-process.
- *    If any update is received for a non-exisitent entry, it is treated
+ *    If any update is received for a non-existent entry, it is treated
  *    as NEW since it contains the base five tuple information required to
  *    identify flow. Similarly, if a destroy event is received for a
  *    non-existent entry, it is ignored.
@@ -203,9 +207,6 @@ dump_conntrack(struct save_targets *targets)
  *
  * The above workflow is used to maintain a local copy of the CT entries for
  * the VM.
- *
- * NOTE: zone-mode cleanup (Clear/delete) is deferred to Step 3; the zone
- * branch deliberately does not start the delete thread.
  *
  * Args:
  *   @targets SAVE targets bundle (mode-aware) for which CT entries have
@@ -226,6 +227,7 @@ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
 
         // Start the delete thread.
         // NOTE: ct_del_args is an extern global variable
+        ct_del_args.kind         = SAVE_INPUT_IPS;
         ct_del_args.ips_migrated = targets->ips_to_migrate;
 
         num_ips = g_hash_table_size(targets->ips_to_migrate);
@@ -324,6 +326,27 @@ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
             return 0;
         }
 
+        // Wire up the delete-thread state for zone mode.
+        // NOTE: ct_del_args is an extern global variable
+        ct_del_args.kind           = SAVE_INPUT_PORT_ZONES;
+        ct_del_args.zones_migrated = targets->zones_to_migrate;
+
+        // Conntrack delete thread (mode-aware: dispatches on
+        // ct_del_args.kind when on_clear wakes it up).
+        ret = pthread_create(&ct_del_args.tid, NULL,
+                             &delete_ct_entries,
+                             (void *)&ct_del_args);
+        if (ret != 0) {
+            LOG(ERROR, "%s: CT delete thread creation failed. %s", __func__,
+                strerror(ret));
+            return -1;
+        }
+        ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
+        if (ret != 0) {
+            LOG(WARNING, "%s: Failed to set thread name \"ct_delete\": %s",
+                __func__, strerror(ret));
+        }
+
         // BPF can't filter on CT zone, so we don't split src/dst threads.
         // One unfiltered events thread is enough; the callback does the
         // zone match in-process.
@@ -348,9 +371,10 @@ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
         // Get all the conntrack entries for the given zones.
         dump_conntrack(targets);
 
-        // Wait for the events thread to be stopped. Zone-mode cleanup
-        // (Clear/delete) is deferred to Step 3; no delete thread to join.
+        // Wait for the events thread, then the delete thread. Same order
+        // as the IP branch above.
         pthread_join(zone_targs->tid, NULL);
+        pthread_join(ct_del_args.tid, NULL);
 
         g_free(zone_targs);
 

--- a/src/main.c
+++ b/src/main.c
@@ -151,11 +151,6 @@ pthread_wrapper_ct_events(void *data)
     struct ct_events_targs *targs;
     struct mnl_socket *nl;
 
-    if (data == NULL) {
-        LOG(ERROR, "%s: data is NULL", __func__);
-        return NULL;
-    }
-
     targs = (struct ct_events_targs *) data;
     LOG(INFO, "%s: Starting conntrack events thread. is_src = %d", __func__,
         targs->is_src);
@@ -460,12 +455,13 @@ create_zones_ht_from_args(char *argv[], int n_entries)
     int i;
     const char **zones;
     GHashTable *ht;
+    const int old_zone_offset = 1;
 
     zones = g_malloc0(sizeof(*zones) * n_entries);
     for (i = 0; i < n_entries; i++) {
         int port_uuid_index =
             ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
-        int zone_index = port_uuid_index + 1;
+        int zone_index = port_uuid_index + old_zone_offset;
         zones[i] = argv[zone_index];
     }
 
@@ -477,6 +473,80 @@ create_zones_ht_from_args(char *argv[], int n_entries)
         return NULL;
     }
     return ht;
+}
+
+/**
+ * Parses N port-zone-remap entries out of argv into an
+ * old_zone -> new_zone hashtable for LOAD-mode use.
+ *
+ * Mirrors create_zones_ht_from_args() on the SAVE side. The port_uuid
+ * column at offset 0 is intentionally ignored: at LOAD time each CT
+ * entry only carries ATTR_ZONE, so the only usable pivot is
+ * old_zone -> new_zone. UUID well-formedness has already been
+ * validated by check_zone_load_args() pre-fork.
+ *
+ * If two entries declare the same old_zone with different new_zones,
+ * the last write wins and a WARNING is logged.
+ *
+ * Args:
+ *   @argv      full argv array.
+ *   @n_entries declared entry count from cli_mode_config.num_entries
+ *              (already validated by check_zone_load_args pre-fork;
+ *              must be > 0 - caller branches on load_kind first).
+ *
+ * Returns:
+ *   remap hashtable on success (caller owns it), NULL on parse
+ *   failure (partially-built remap is torn down before returning).
+ */
+static GHashTable *
+build_zone_remap_from_args(char *argv[], int n_entries)
+{
+    GHashTable *remap;
+    int i;
+    const int old_zone_offset = 1;
+    const int new_zone_offset = 2;
+
+    if (n_entries <= 0) {
+        LOG(ERROR, "%s: non-positive n_entries (%d)", __func__, n_entries);
+        return NULL;
+    }
+
+    remap = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    for (i = 0; i < n_entries; i++) {
+        int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
+        const char *old_zone_str = argv[base + old_zone_offset];
+        const char *new_zone_str = argv[base + new_zone_offset];
+        uint16_t old_zone, new_zone;
+        gpointer existing_val;
+
+        if (!parse_ct_zone(old_zone_str, &old_zone) ||
+            !parse_ct_zone(new_zone_str, &new_zone)) {
+            LOG(ERROR, "%s: failed to parse zone at entry %d "
+                "(old='%s' new='%s')",
+                __func__, i, old_zone_str, new_zone_str);
+            g_hash_table_destroy(remap);
+            return NULL;
+        }
+
+        if (g_hash_table_lookup_extended(remap,
+                                         GUINT_TO_POINTER((guint) old_zone),
+                                         NULL, &existing_val)) {
+            uint16_t existing = (uint16_t) GPOINTER_TO_UINT(existing_val);
+            if (existing != new_zone) {
+                LOG(WARNING, "%s: old_zone %u remapped twice "
+                    "(was -> %u, now -> %u). Last write wins.",
+                    __func__, (unsigned) old_zone,
+                    (unsigned) existing, (unsigned) new_zone);
+            }
+        }
+
+        g_hash_table_insert(remap,
+                            GUINT_TO_POINTER((guint) old_zone),
+                            GUINT_TO_POINTER((guint) new_zone));
+    }
+
+    return remap;
 }
 
 /**
@@ -649,7 +719,6 @@ dmain(int argc, char *argv[], const struct cli_mode_config *cli)
     (void) argc;
 
     if (argv == NULL || cli == NULL) {
-        /* log facility not initialised yet; bail with a distinct rc. */
         return EINVAL;
     }
 
@@ -707,15 +776,14 @@ dmain(int argc, char *argv[], const struct cli_mode_config *cli)
             dbus_server_args.load_targets = load_targets_new_ips();
             LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
         } else {
-            dbus_server_args.load_targets =
-                load_targets_new_from_zone_args(cli->num_entries, argv,
-                                                ENTRIES_LIST_START_ARG_INDEX,
-                                                LOAD_PORT_ZONE_STRIDE);
-            if (dbus_server_args.load_targets == NULL) {
-                LOG(ERROR, "%s: failed to build load_targets", __func__);
+            GHashTable *remap = build_zone_remap_from_args(argv,
+                                                           cli->num_entries);
+            if (remap == NULL) {
+                LOG(ERROR, "%s: failed to build zone remap", __func__);
                 rc = EINVAL;
                 goto cleanup;
             }
+            dbus_server_args.load_targets = load_targets_new_from_remap(remap);
             LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
                 __func__, cli->num_entries);
         }
@@ -898,6 +966,7 @@ check_zone_save_args(int argc, char *argv[])
 {
     int n;
     int i;
+    const int old_zone_offset = 1;
 
     (void) argc;
 
@@ -908,7 +977,7 @@ check_zone_save_args(int argc, char *argv[])
     for (i = 0; i < n; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
         const char *port_uuid = argv[base];
-        const char *zone_str  = argv[base + 1];
+        const char *zone_str  = argv[base + old_zone_offset];
         uint16_t zone_val;
 
         if (!is_valid_uuid_string(port_uuid)) {
@@ -939,6 +1008,8 @@ check_zone_load_args(int argc, char *argv[])
 {
     int n;
     int i;
+    const int old_zone_offset = 1;
+    const int new_zone_offset = 2;
 
     (void) argc;
 
@@ -949,8 +1020,8 @@ check_zone_load_args(int argc, char *argv[])
     for (i = 0; i < n; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
         const char *port_uuid    = argv[base];
-        const char *old_zone_str = argv[base + 1];
-        const char *new_zone_str = argv[base + 2];
+        const char *old_zone_str = argv[base + old_zone_offset];
+        const char *new_zone_str = argv[base + new_zone_offset];
         uint16_t z;
 
         if (!is_valid_uuid_string(port_uuid)) {

--- a/src/main.c
+++ b/src/main.c
@@ -84,17 +84,36 @@
 #define MAX_IP_ADDRESSES_SUPPORTED      127
 
 /**
- * Result of CLI parsing - filled by check_args() and consumed by main().
+ * Result of CLI parsing - filled by check_args() pre-fork and consumed
+ * by dmain() post-fork. Threading the parsed result through avoids
+ * re-walking argv inside the daemon: fork() copies the entire address
+ * space (including main's stack frame), so the struct is valid in the
+ * grandchild and is read verbatim.
  *
  * The sub-kind field is a tagged union: the active arm is determined by
  * @mode (SAVE_MODE -> save_kind, LOAD_MODE -> load_kind).
+ *
+ * @num_entries holds the declared entry count from
+ * argv[NUM_ENTRIES_ARG_INDEX] when applicable:
+ *   - SAVE IP-mode "no IPv4 NICs" path  (argc <= 4):  0
+ *   - SAVE IP-mode standard:                          num_ips
+ *   - SAVE port-zone mode:                            N
+ *   - LOAD legacy:                                    0
+ *   - LOAD port-zone mode:                            N
+ * Consumers that legitimately accept 0 (the no-IPv4-NICs path) must
+ * treat 0 as "list absent" rather than "list empty bad".
+ *
+ * num_entries is captured by detect_*_input_kind during its existing
+ * shape-detection parse and propagated up through check_*_mode_args -
+ * check_args does not parse argv[3] a second time.
  */
-struct parsed_cli {
+struct cli_mode_config {
     enum op_mode mode;
     union {
         enum save_input_kind save_kind;
         enum load_input_kind load_kind;
     };
+    int num_entries;
 };
 
 const char *lmct_config_path = "/etc/lmct_config";
@@ -385,25 +404,22 @@ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
 }
 
 /**
- * Creates hashtable of IP addresses from CLI arguments.
+ * Creates the ips_to_migrate hashtable from the legacy SAVE-mode CLI.
  *
  * Args:
- *   @argv array of CLI args.
+ *   @argv    array of CLI args.
+ *   @num_ips declared IP count from cli_mode_config.num_entries
+ *            (already validated by check_ip_save_args pre-fork). May
+ *            legitimately be 0 ("VM has no IPv4 NICs"; see the early
+ *            exit in start_in_save_mode).
  *
  * Returns:
  *   Resulting hashtable containing IP address(uint32_t) as key.
  */
 static GHashTable *
-create_ips_ht_from_args(char *argv[])
+create_ips_ht_from_args(char *argv[], int num_ips)
 {
-    int num_ips;
     GHashTable *ht;
-
-    /* MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS is 0 because the legacy IP form
-     * legitimately accepts num_ips == 0 ("VM has no IPv4 NICs"; see the
-     * early-exit in start_in_save_mode). */
-    ensure_cli_arg_is_int_at_least(argv[NUM_IP_ADDR_ARG_INDEX], &num_ips,
-                                   "num_ips", MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS);
     const char **ips = (const char **)(argv + IP_ADDR_LIST_ARG_INDEX);
 
     ht = create_hashtable_from_ip_list(ips, num_ips);
@@ -426,26 +442,26 @@ create_ips_ht_from_args(char *argv[])
  * create_hashtable_from_zone_list().
  *
  * Args:
- *   @argv array of CLI args.
+ *   @argv      array of CLI args.
+ *   @n_entries declared entry count from cli_mode_config.num_entries
+ *              (already validated by check_zone_save_args pre-fork).
  *
  * Returns:
  *   zones_to_migrate hashtable on success, NULL on failure.
  */
 static GHashTable *
-create_zones_ht_from_args(char *argv[])
+create_zones_ht_from_args(char *argv[], int n_entries)
 {
-    int n_entries;
     int i;
     const char **zones;
     GHashTable *ht;
 
-    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n_entries,
-                                   "num_entries",
-                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
     zones = g_malloc0(sizeof(*zones) * n_entries);
     for (i = 0; i < n_entries; i++) {
-        int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
-        zones[i] = argv[base + 1];
+        int port_uuid_index =
+            ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
+        int zone_index = port_uuid_index + 1;
+        zones[i] = argv[zone_index];
     }
 
     ht = create_hashtable_from_zone_list(zones, n_entries);
@@ -469,37 +485,40 @@ create_zones_ht_from_args(char *argv[])
  * The "no list / N == 0" cases default to SAVE_INPUT_IPS so the existing
  * "VM with no IPv4 NICs" passthrough in start_in_save_mode() stays intact.
  *
- * NOTE: this lives in the runtime (post-fork) section of the file, above
- * dmain(), because dmain re-runs the detection after the double fork to
- * recover the SAVE sub-kind without threading it through a new parameter.
- * The pre-fork validator block below uses the same function for shape
- * checking; we deliberately keep one definition shared by both call sites.
+ * Called once pre-fork from check_save_mode_args(); the detected kind
+ * and declared N are recorded on cli_mode_config and read by dmain()
+ * after the double fork rather than re-detected.
  *
  * Args:
- *   @argc num of CLI arguments.
- *   @argv array of CLI arguments.
+ *   @argc           num of CLI arguments.
+ *   @argv           array of CLI arguments.
+ *   @out_n_entries  output for the declared entry count. Set to 0 on the
+ *                   "no list" shortcut so the caller can record it on
+ *                   cli_mode_config without an extra parse of argv[3].
  *
  * Returns:
  *   The detected sub-mode. Aborts the process via errx() on a shape
  *   mismatch (declared N is non-zero but trailing args fit neither layout).
  */
 static enum save_input_kind
-detect_save_input_kind(int argc, char *argv[])
+detect_save_input_kind(int argc, char *argv[], int *out_n_entries)
 {
     int n;
     int remaining;
 
     if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
+        *out_n_entries = 0;
         return SAVE_INPUT_IPS;
     }
 
     ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
                                    "num_entries",
                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
+    *out_n_entries = n;
 
     remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
 
-    if (remaining == n * 1) {
+    if (remaining == n) {
         return SAVE_INPUT_IPS;
     }
     if (remaining == n * SAVE_PORT_ZONE_STRIDE) {
@@ -523,27 +542,29 @@ detect_save_input_kind(int argc, char *argv[])
  * Anything else is a hard error - we deliberately do NOT silently fall back
  * to legacy if the trailing args do not match the new shape.
  *
- * NOTE: this lives in the runtime (post-fork) section of the file, above
- * dmain(), because dmain re-runs the detection after the double fork to
- * recover the LOAD sub-kind without threading it through a new parameter.
- * The pre-fork validator block below uses the same function for shape
- * checking; we deliberately keep one definition shared by both call sites
- * (mirroring detect_save_input_kind above).
+ * Called once pre-fork from check_load_mode_args(); the detected kind
+ * and declared N are recorded on cli_mode_config and read by dmain()
+ * after the double fork rather than re-detected (mirroring
+ * detect_save_input_kind above).
  *
  * Args:
- *   @argc num of CLI arguments.
- *   @argv array of CLI arguments.
+ *   @argc           num of CLI arguments.
+ *   @argv           array of CLI arguments.
+ *   @out_n_entries  output for the declared entry count. Set to 0 on the
+ *                   legacy shortcut so the caller can record it on
+ *                   cli_mode_config without an extra parse of argv[3].
  *
  * Returns:
  *   The detected sub-mode. Aborts the process via errx() on any mismatch.
  */
 static enum load_input_kind
-detect_load_input_kind(int argc, char *argv[])
+detect_load_input_kind(int argc, char *argv[], int *out_n_entries)
 {
     int n;
     int remaining;
 
     if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
+        *out_n_entries = 0;
         return LOAD_INPUT_LEGACY;
     }
 
@@ -558,6 +579,7 @@ detect_load_input_kind(int argc, char *argv[])
     ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
                                    "LOAD num_entries",
                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
+    *out_n_entries = n;
 
     remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
 
@@ -574,10 +596,9 @@ detect_load_input_kind(int argc, char *argv[])
 /**
  * Checks if the mode passed is either LOAD or SAVE.
  *
- * Defined here (rather than next to the other check_* validators
- * below) because dmain calls it directly after parsing argv[MODE]
- * to defend against an out-of-set mode reaching the post-fork
- * grandchild. check_args() below also calls it pre-fork.
+ * Called once pre-fork from check_args(); an out-of-set mode aborts
+ * the process via errx() before fork happens, so dmain() is guaranteed
+ * to receive a valid cli_mode_config.mode value.
  *
  * Args:
  *   @mode operating mode
@@ -595,17 +616,21 @@ check_mode(int mode)
  * Entry point for the daemon.
  *
  * Args:
- *   @argc num of arguments to the application
- *   @argv string argument list
+ *   @argc num of arguments to the application.
+ *   @argv string argument list.
+ *   @cli  parsed CLI bundle populated by check_args() before the
+ *         daemon was forked. Mode, sub-kind, and num_entries are read
+ *         directly from here instead of re-walking argv. fork() copies
+ *         the entire address space (including the parent's stack frame),
+ *         so the pointer is valid in the grandchild.
  *
  * Returns:
  *   0 if the daemon exits without any error. otherwise the specific error
  *   code is returned.
  */
 static int
-dmain(int argc, char *argv[])
+dmain(int argc, char *argv[], const struct cli_mode_config *cli)
 {
-    int mode;
     const char *helper_id;
     int ret;
     int rc = 0;
@@ -615,23 +640,10 @@ dmain(int argc, char *argv[])
     bool loop_mu_inited = false;
     struct dbus_targs dbus_server_args = {0};
     struct save_targets *save_targets = NULL;
-    enum save_input_kind save_kind = SAVE_INPUT_IPS;
 
-    // Parse the command line arguments. check_mode runs the value-set
-    // check (mode must be 1 or 2); ensure_cli_arg_is_int_at_least only
-    // guarantees mode is a positive int and would happily accept "3".
-    ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
-                                   MIN_ACCEPTABLE_VALUE_FOR_MODE);
-    check_mode(mode);
+    (void) argc;
+
     helper_id = argv[HELPER_ID_ARG_INDEX];
-
-    // Re-detect the SAVE sub-kind here because we don't currently thread
-    // the parent's parsed_cli through the double fork (CR5 will fix
-    // that). argv is preserved across forks, so detection is cheap and
-    // side-effect-free.
-    if (mode == SAVE_MODE) {
-        save_kind = detect_save_input_kind(argc, argv);
-    }
 
     // Initialise logging at default INFO level.
     ret = init_log(INFO, helper_id);
@@ -646,7 +658,8 @@ dmain(int argc, char *argv[])
     // set the logging level read from config.
     set_log_level(lmct_conf.log_lvl);
 
-    LOG(INFO, "%s: Starting in mode %s", __func__, mode_to_string[mode]);
+    LOG(INFO, "%s: Starting in mode %s", __func__,
+        mode_to_string[cli->mode]);
     LOG(INFO, "%s: dbus address %s", __func__,
         getenv("DBUS_SYSTEM_BUS_ADDRESS"));
     LOG(INFO, "%s: helper id: %s", __func__, helper_id);
@@ -664,7 +677,7 @@ dmain(int argc, char *argv[])
     // Start the dbus server
     dbus_server_args.helper_id    = helper_id;
     dbus_server_args.stop_flag    = &stop_flag;
-    dbus_server_args.mode         = (enum op_mode) mode;
+    dbus_server_args.mode         = cli->mode;
     dbus_server_args.load_targets = NULL;
     dbus_server_args.loop         = NULL;
     dbus_server_args.should_quit  = false;
@@ -679,19 +692,13 @@ dmain(int argc, char *argv[])
     /* In LOAD mode build the (old_zone -> new_zone) remap up-front so the
      * dbus thread has it ready by the time the destination's Load IPC
      * arrives. SAVE mode leaves load_targets NULL. */
-    if (mode == LOAD_MODE) {
-        enum load_input_kind load_kind = detect_load_input_kind(argc, argv);
-
-        if (load_kind == LOAD_INPUT_LEGACY) {
+    if (cli->mode == LOAD_MODE) {
+        if (cli->load_kind == LOAD_INPUT_LEGACY) {
             dbus_server_args.load_targets = load_targets_new_ips();
             LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
         } else {
-            int n;
-            ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
-                                           "num_entries",
-                                           MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
             dbus_server_args.load_targets =
-                load_targets_new_from_zone_args(n, argv,
+                load_targets_new_from_zone_args(cli->num_entries, argv,
                                                 ENTRIES_LIST_START_ARG_INDEX,
                                                 LOAD_PORT_ZONE_STRIDE);
             if (dbus_server_args.load_targets == NULL) {
@@ -700,7 +707,7 @@ dmain(int argc, char *argv[])
                 goto cleanup;
             }
             LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
-                __func__, n);
+                __func__, cli->num_entries);
         }
     }
 
@@ -721,17 +728,18 @@ dmain(int argc, char *argv[])
     }
 
     // Start save mode threads.
-    if (mode == SAVE_MODE) {
-        if (save_kind == SAVE_INPUT_IPS) {
+    if (cli->mode == SAVE_MODE) {
+        if (cli->save_kind == SAVE_INPUT_IPS) {
             GHashTable *ips_to_migrate;
-            ips_to_migrate = create_ips_ht_from_args(argv);
+            ips_to_migrate = create_ips_ht_from_args(argv, cli->num_entries);
             if (ips_to_migrate == NULL) {
                 rc = EINVAL;
                 goto cleanup;
             }
             save_targets = save_targets_new_from_ips(ips_to_migrate);
         } else {
-            GHashTable *zones_ht = create_zones_ht_from_args(argv);
+            GHashTable *zones_ht =
+                create_zones_ht_from_args(argv, cli->num_entries);
             if (zones_ht == NULL) {
                 rc = EINVAL;
                 goto cleanup;
@@ -958,23 +966,30 @@ check_zone_load_args(int argc, char *argv[])
  *
  * Picks IP vs port-zone via detect_save_input_kind() and delegates
  * per-entry validation to the appropriate validator. Reports the
- * detected sub-kind to the caller via @out_kind.
+ * detected sub-kind and the declared entry count to the caller so they
+ * can be recorded on cli_mode_config without an extra argv parse.
  *
  * Args:
- *   @argc     num of arguments.
- *   @argv     array of CLI arguments.
- *   @out_kind output pointer for the detected sub-kind. May be NULL.
+ *   @argc          num of arguments.
+ *   @argv          array of CLI arguments.
+ *   @out_kind      output pointer for the detected sub-kind. May be NULL.
+ *   @out_n_entries output pointer for the declared entry count, captured
+ *                  from detect_save_input_kind's existing parse. May be
+ *                  NULL. 0 on the SAVE-IP "no list" shortcut.
  */
 static void
 check_save_mode_args(int argc, char *argv[],
-                     enum save_input_kind *out_kind)
+                     enum save_input_kind *out_kind,
+                     int *out_n_entries)
 {
-    enum save_input_kind kind = detect_save_input_kind(argc, argv);
+    int n_entries = 0;
+    enum save_input_kind kind =
+        detect_save_input_kind(argc, argv, &n_entries);
 
     if (kind == SAVE_INPUT_IPS) {
         check_ip_save_args(argc, argv);
     } else {
-        if(kind == SAVE_INPUT_PORT_ZONES) {
+        if (kind == SAVE_INPUT_PORT_ZONES) {
             check_zone_save_args(argc, argv);
         } else {
             errx(EXIT_FAILURE, "Invalid save input kind: %d", kind);
@@ -984,6 +999,9 @@ check_save_mode_args(int argc, char *argv[],
     if (out_kind != NULL) {
         *out_kind = kind;
     }
+    if (out_n_entries != NULL) {
+        *out_n_entries = n_entries;
+    }
 }
 
 /**
@@ -991,29 +1009,39 @@ check_save_mode_args(int argc, char *argv[],
  *
  * Legacy LOAD takes no extra args beyond <mode> <helper_id>; the new LOAD
  * port-zone layout is content-validated. Reports the detected sub-kind
- * to the caller via @out_kind.
+ * and the declared entry count to the caller so they can be recorded on
+ * cli_mode_config without an extra argv parse.
  *
  * Args:
- *   @argc     num of arguments.
- *   @argv     array of CLI arguments.
- *   @out_kind output pointer for the detected sub-kind. May be NULL.
+ *   @argc          num of arguments.
+ *   @argv          array of CLI arguments.
+ *   @out_kind      output pointer for the detected sub-kind. May be NULL.
+ *   @out_n_entries output pointer for the declared entry count, captured
+ *                  from detect_load_input_kind's existing parse. May be
+ *                  NULL. 0 on the LOAD legacy shortcut.
  */
 static void
 check_load_mode_args(int argc, char *argv[],
-                     enum load_input_kind *out_kind)
+                     enum load_input_kind *out_kind,
+                     int *out_n_entries)
 {
-    enum load_input_kind kind = detect_load_input_kind(argc, argv);
+    int n_entries = 0;
+    enum load_input_kind kind =
+        detect_load_input_kind(argc, argv, &n_entries);
 
     if (kind == LOAD_INPUT_PORT_ZONES) {
         check_zone_load_args(argc, argv);
-    }else{
-        if(kind != LOAD_INPUT_LEGACY) {
+    } else {
+        if (kind != LOAD_INPUT_LEGACY) {
             errx(EXIT_FAILURE, "Invalid load input kind: %d", kind);
         }
     }
 
     if (out_kind != NULL) {
         *out_kind = kind;
+    }
+    if (out_n_entries != NULL) {
+        *out_n_entries = n_entries;
     }
 }
 
@@ -1036,7 +1064,7 @@ check_load_mode_args(int argc, char *argv[],
  *   @out  output struct populated with the parse result. Must be non-NULL.
  */
 static void
-check_args(int argc, char *argv[], struct parsed_cli *out)
+check_args(int argc, char *argv[], struct cli_mode_config *out)
 {
     int mode;
 
@@ -1051,10 +1079,15 @@ check_args(int argc, char *argv[], struct parsed_cli *out)
     check_mode(mode);
     out->mode = (enum op_mode) mode;
 
+    /* num_entries is populated by the mode-specific dispatcher, which
+     * in turn picks it up from detect_*_input_kind's existing parse -
+     * no second call to ensure_cli_arg_is_int_at_least on argv[3]. */
     if (mode == SAVE_MODE) {
-        check_save_mode_args(argc, argv, &out->save_kind);
+        check_save_mode_args(argc, argv, &out->save_kind,
+                             &out->num_entries);
     } else {
-        check_load_mode_args(argc, argv, &out->load_kind);
+        check_load_mode_args(argc, argv, &out->load_kind,
+                             &out->num_entries);
     }
 }
 
@@ -1085,11 +1118,13 @@ int
 main(int argc, char *argv[])
 {
     int child_pid;
-    struct parsed_cli cli = {0};
+    struct cli_mode_config cli = {0};
 
-    // Validate CLI args + decide IP-vs-zone sub-kind before any forks.
-    // The result is recomputed inside dmain() because the parent's stack
-    // (and thus this `cli`) is gone by the time the grandchild runs.
+    /* Validate CLI args + decide IP-vs-zone sub-kind before any forks.
+     * fork() preserves the parent's address space (copy-on-write of
+     * the entire AS, including this stack frame), so `cli` is still
+     * readable in the grandchild and is passed directly to dmain()
+     * rather than being re-parsed there. */
     check_args(argc, argv, &cli);
 
     // Fork child
@@ -1118,7 +1153,7 @@ main(int argc, char *argv[])
             }
 
             // start the daemon
-            ret = dmain(argc, argv);
+            ret = dmain(argc, argv, &cli);
             exit((ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE));
         } else {
             // Child process

--- a/src/main.c
+++ b/src/main.c
@@ -151,6 +151,11 @@ pthread_wrapper_ct_events(void *data)
     struct ct_events_targs *targs;
     struct mnl_socket *nl;
 
+    if (data == NULL) {
+        LOG(ERROR, "%s: data is NULL", __func__);
+        return NULL;
+    }
+
     targs = (struct ct_events_targs *) data;
     LOG(INFO, "%s: Starting conntrack events thread. is_src = %d", __func__,
         targs->is_src);
@@ -643,6 +648,11 @@ dmain(int argc, char *argv[], const struct cli_mode_config *cli)
 
     (void) argc;
 
+    if (argv == NULL || cli == NULL) {
+        /* log facility not initialised yet; bail with a distinct rc. */
+        return EINVAL;
+    }
+
     helper_id = argv[HELPER_ID_ARG_INDEX];
 
     // Initialise logging at default INFO level.
@@ -1067,6 +1077,12 @@ static void
 check_args(int argc, char *argv[], struct cli_mode_config *out)
 {
     int mode;
+
+    if (argv == NULL || out == NULL) {
+        errx(EXIT_FAILURE,
+             "%s: argv=%p out=%p (both must be non-NULL)",
+             __func__, (void *)argv, (void *)out);
+    }
 
     if (argc < 3) {
         err_usage();

--- a/src/main.c
+++ b/src/main.c
@@ -313,11 +313,9 @@ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
         g_free(src_targs);
         g_free(dst_targs);
 
-        return 0;
-    }
+    } else {
 
-    /* SAVE_INPUT_PORT_ZONES */
-    {
+         /* SAVE_INPUT_PORT_ZONES */
         uint32_t num_zones = g_hash_table_size(targets->zones_to_migrate);
 
         if (num_zones == 0) {
@@ -356,8 +354,9 @@ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
 
         g_free(zone_targs);
 
-        return 0;
     }
+
+    return 0;
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -398,7 +398,11 @@ create_ips_ht_from_args(char *argv[])
     int num_ips;
     GHashTable *ht;
 
-    num_ips = atoi(argv[NUM_IP_ADDR_ARG_INDEX]);
+    /* MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS is 0 because the legacy IP form
+     * legitimately accepts num_ips == 0 ("VM has no IPv4 NICs"; see the
+     * early-exit in start_in_save_mode). */
+    ensure_cli_arg_is_int_at_least(argv[NUM_IP_ADDR_ARG_INDEX], &num_ips,
+                                   "num_ips", MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS);
     const char **ips = (const char **)(argv + IP_ADDR_LIST_ARG_INDEX);
 
     ht = create_hashtable_from_ip_list(ips, num_ips);
@@ -435,7 +439,9 @@ create_zones_and_port_ht_from_args(char *argv[], GHashTable **out_ports)
     const char **port_uuids;
     GHashTable *ht;
 
-    n_entries = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n_entries,
+                                   "num_entries",
+                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
     zones = g_malloc0(sizeof(*zones) * n_entries);
     port_uuids = g_malloc0(sizeof(*port_uuids) * n_entries);
     for (i = 0; i < n_entries; i++) {
@@ -491,10 +497,9 @@ detect_save_input_kind(int argc, char *argv[])
         return SAVE_INPUT_IPS;
     }
 
-    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
-    if (n <= 0) {
-        return SAVE_INPUT_IPS;
-    }
+    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                   "num_entries",
+                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
 
     remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
 
@@ -554,13 +559,9 @@ detect_load_input_kind(int argc, char *argv[])
              "<port_uuid> <old_zone> <new_zone> ...`.");
     }
 
-    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
-    if (n <= 0) {
-        errx(EXIT_FAILURE,
-             "LOAD mode: invalid number of port-zone entries: '%s' "
-             "(must be a positive integer).",
-             argv[NUM_ENTRIES_ARG_INDEX]);
-    }
+    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                   "LOAD num_entries",
+                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
 
     remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
 
@@ -572,6 +573,26 @@ detect_load_input_kind(int argc, char *argv[])
          "LOAD mode: argv shape mismatch. N=%d, expected %d args "
          "(port-zone form), got %d.",
          n, n * LOAD_PORT_ZONE_STRIDE, remaining);
+}
+
+/**
+ * Checks if the mode passed is either LOAD or SAVE.
+ *
+ * Defined here (rather than next to the other check_* validators
+ * below) because dmain calls it directly after parsing argv[MODE]
+ * to defend against an out-of-set mode reaching the post-fork
+ * grandchild. check_args() below also calls it pre-fork.
+ *
+ * Args:
+ *   @mode operating mode
+ */
+static void
+check_mode(int mode)
+{
+    if ((mode != LOAD_MODE) && (mode != SAVE_MODE)) {
+        errx(EXIT_FAILURE, "Incorrect mode passed. Should be 1 (LOAD) or "
+                "2 (SAVE)\n");
+    }
 }
 
 /**
@@ -600,8 +621,12 @@ dmain(int argc, char *argv[])
     struct save_targets *save_targets = NULL;
     enum save_input_kind save_kind = SAVE_INPUT_IPS;
 
-    // Parse the command line arguments.
-    mode = atoi(argv[MODE_ARG_INDEX]);
+    // Parse the command line arguments. check_mode runs the value-set
+    // check (mode must be 1 or 2); ensure_cli_arg_is_int_at_least only
+    // guarantees mode is a positive int and would happily accept "3".
+    ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
+                                   MIN_ACCEPTABLE_VALUE_FOR_MODE);
+    check_mode(mode);
     helper_id = argv[HELPER_ID_ARG_INDEX];
 
     // Re-detect the SAVE sub-kind here because we don't currently thread
@@ -665,7 +690,10 @@ dmain(int argc, char *argv[])
             dbus_server_args.load_targets = load_targets_new_ips();
             LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
         } else {
-            int n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+            int n;
+            ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                           "num_entries",
+                                           MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
             dbus_server_args.load_targets =
                 load_targets_new_from_zone_args(n, argv,
                                                 ENTRIES_LIST_START_ARG_INDEX,
@@ -789,21 +817,6 @@ err_usage(void)
 }
 
 /**
- * Checks if the mode passed is either LOAD or SAVE.
- *
- * Args:
- *   @mode operating mode
- */
-static void
-check_mode(int mode)
-{
-    if ((mode != LOAD_MODE) && (mode != SAVE_MODE)) {
-        errx(EXIT_FAILURE, "Incorrect mode passed. Should be 1 (LOAD) or "
-                "2 (SAVE)\n");
-    }
-}
-
-/**
  * Checks if the DBUS_SYSTEM_BUS_ADDRESS env variable is set.
  */
 static void
@@ -840,9 +853,17 @@ check_ip_save_args(int argc, char *argv[])
         errx(EXIT_FAILURE, "Number of IP addresses not present in args");
     }
 
-    num_ip_addr = atoi(argv[NUM_IP_ADDR_ARG_INDEX]);
-    if (num_ip_addr < 0 || num_ip_addr > (argc - IP_ADDR_LIST_ARG_INDEX)) {
-        errx(EXIT_FAILURE, "Invalid argument for number of IP addresses");
+    /* min_value = 0 (not 1) because num_ip_addr == 0 is the legitimate
+     * "VM has no IPv4 NICs" case. The helper rejects negatives and
+     * non-numeric input; we still need the count-vs-argc check below
+     * to catch "I declared 5 IPs but only passed 2". */
+    ensure_cli_arg_is_int_at_least(argv[NUM_IP_ADDR_ARG_INDEX], &num_ip_addr,
+                                   "num_ips", MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS);
+    if (num_ip_addr > (argc - IP_ADDR_LIST_ARG_INDEX)) {
+        errx(EXIT_FAILURE,
+             "Declared num_ips (%d) exceeds the number of IP addresses "
+             "supplied in argv (%d)",
+             num_ip_addr, argc - IP_ADDR_LIST_ARG_INDEX);
     }
 }
 
@@ -867,9 +888,11 @@ check_zone_save_args(int argc, char *argv[])
     int n;
     int i;
 
-    (void) argc;   /* arity already checked by the detector */
+    (void) argc;
 
-    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                   "num_entries",
+                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
 
     for (i = 0; i < n; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
@@ -908,7 +931,9 @@ check_zone_load_args(int argc, char *argv[])
 
     (void) argc;
 
-    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                   "num_entries",
+                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
 
     for (i = 0; i < n; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
@@ -1028,7 +1053,8 @@ check_args(int argc, char *argv[], struct parsed_cli *out)
 
     check_dbus_address_env();
 
-    mode = atoi(argv[MODE_ARG_INDEX]);
+    ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
+                                   MIN_ACCEPTABLE_VALUE_FOR_MODE);
     check_mode(mode);
     out->mode = (enum op_mode) mode;
 

--- a/src/main.c
+++ b/src/main.c
@@ -207,6 +207,90 @@ dump_conntrack(struct save_targets *targets)
 }
 
 /**
+ * Spawn a single ct_events thread with the given is_src flag and
+ * pthread name. On success the thread owns the freshly allocated
+ * struct ct_events_targs and the caller receives it via @out_targs
+ * for later pthread_join + g_free. On failure @*out_targs is left
+ * untouched and the partial allocation is released here.
+ *
+ * Args:
+ *   @targets     SAVE targets bundle threaded down to the events
+ *                callback (read-only over the thread's lifetime).
+ *   @stop_flag   shared stop flag the thread polls for graceful exit.
+ *   @is_src      true for src-filtered BPF (IP mode src thread);
+ *                false for dst-filtered (IP mode dst thread) or for
+ *                the unfiltered zone-mode thread.
+ *   @thread_name pthread_setname_np tag; logged on rename failure.
+ *   @out_targs   output: owning pointer to the thread args bundle.
+ *
+ * Returns:
+ *   0 on success, -1 on pthread_create failure.
+ */
+static int
+create_events_thread(struct save_targets *targets, bool *stop_flag,
+                     bool is_src, const char *thread_name,
+                     struct ct_events_targs **out_targs)
+{
+    struct ct_events_targs *targs;
+    int ret;
+
+    targs = g_malloc0(sizeof(*targs));
+    targs->targets   = targets;
+    targs->stop_flag = stop_flag;
+    targs->is_src    = is_src;
+
+    ret = pthread_create(&targs->tid, NULL, &pthread_wrapper_ct_events, targs);
+    if (ret != 0) {
+        LOG(ERROR, "%s: events thread '%s' creation failed: %s",
+            __func__, thread_name, strerror(ret));
+        g_free(targs);
+        return -1;
+    }
+    ret = pthread_setname_np(targs->tid, thread_name);
+    if (ret != 0) {
+        LOG(WARNING, "%s: failed to set thread name '%s': %s",
+            __func__, thread_name, strerror(ret));
+    }
+
+    *out_targs = targs;
+    return 0;
+}
+
+/**
+ * Spawn the conntrack delete thread.
+ *
+ * Mode-aware via ct_del_args.kind and the migrated-set pointers the
+ * caller has already populated on ct_del_args before this call. The
+ * thread is started in BOTH save sub-modes; its lifetime is what
+ * keeps the DBus main loop responsive to on_clear until the Clear
+ * IPC arrives and complete_on_clear drives g_main_loop_quit. Removing
+ * it for a mode would leave pthread_join in dmain waiting forever.
+ *
+ * Returns:
+ *   0 on success, -1 on pthread_create failure (in which case the
+ *   thread does not exist and ct_del_args.tid is left untouched).
+ */
+static int
+create_delete_thread(void)
+{
+    int ret;
+
+    ret = pthread_create(&ct_del_args.tid, NULL,
+                         &delete_ct_entries, (void *)&ct_del_args);
+    if (ret != 0) {
+        LOG(ERROR, "%s: CT delete thread creation failed: %s",
+            __func__, strerror(ret));
+        return -1;
+    }
+    ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
+    if (ret != 0) {
+        LOG(WARNING, "%s: failed to set thread name 'ct_delete': %s",
+            __func__, strerror(ret));
+    }
+    return 0;
+}
+
+/**
  * Start threads required for save mode of operation.
  *
  * Following things are performed in the save mode:
@@ -239,168 +323,100 @@ dump_conntrack(struct save_targets *targets)
 static int
 start_in_save_mode(struct save_targets *targets, bool *stop_flag)
 {
-    int ret;
-    struct ct_events_targs *src_targs, *dst_targs, *zone_targs;
+    struct ct_events_targs *src_targs  = NULL;
+    struct ct_events_targs *dst_targs  = NULL;
+    struct ct_events_targs *zone_targs = NULL;
+    uint32_t num_entries;
 
+    /* Common: arity + early exits. The "no entries" path is not an
+     * error in either mode (e.g. a VM with no IPv4 NICs in IP mode);
+     * QEMU expects the helper to live for the migration window, so we
+     * just skip starting the worker threads and let the DBus loop run. */
     if (targets->kind == SAVE_INPUT_IPS) {
-        uint32_t num_ips;
-
-        // Start the delete thread.
-        // NOTE: ct_del_args is an extern global variable
-        ct_del_args.kind         = SAVE_INPUT_IPS;
-        ct_del_args.ips_migrated = targets->ips_to_migrate;
-
-        num_ips = g_hash_table_size(targets->ips_to_migrate);
-
-        // This happens in case a VM has no IPv4 NICs attached to it. Thus,
-        // the VM will not have any CT entries present in kernel to migrate.
-        // Also, since QEMU expects helper process to be present during
-        // migration, we do not exit the process completely rather just runs
-        // the dbus server to facilitate the IPC calls.
-        if (num_ips == 0) {
-            LOG(INFO, "%s: Not starting any save mode threads since number "
-                "of IP addresses is 0", __func__);
-            return 0;
-        }
-
-        if (num_ips > MAX_IP_ADDRESSES_SUPPORTED) {
-            LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
-                "No Conntrack Migration will be performed.",
-                MAX_IP_ADDRESSES_SUPPORTED);
-            return 0;
-        }
-
-        // Conntrack delete thread.
-        ret = pthread_create(&ct_del_args.tid, NULL,
-                             &delete_ct_entries,
-                             (void *)&ct_del_args);
-        if (ret != 0) {
-            LOG(ERROR, "%s: CT delete thread creation failed. %s", __func__,
-                strerror(ret));
-            return -1;
-        }
-        ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
-        if (ret != 0) {
-            LOG(WARNING, "%s: Failed to set thread name \"ct_delete\": %s",
-                __func__, strerror(ret));
-        }
-
-        // Listen for conntrack events which contains their src IP address
-        // in ips_to_migrate.
-        src_targs = g_malloc0(sizeof(struct ct_events_targs));
-        src_targs->targets = targets;
-        src_targs->stop_flag = stop_flag;
-        src_targs->is_src = true;
-        ret = pthread_create(&src_targs->tid, NULL, &pthread_wrapper_ct_events,
-                             (void *)src_targs);
-        if (ret != 0) {
-            LOG(ERROR, "%s: src events thread creation failed. %s", __func__,
-                strerror(ret));
-            return -1;
-        }
-        ret = pthread_setname_np(src_targs->tid, "ct_events_src");
-        if (ret != 0) {
-            LOG(WARNING, "%s: Failed to set thread name \"ct_events_src\". %s",
-                __func__, strerror(ret));
-        }
-
-        // Listen for conntrack events which contains their dst IP address
-        // in ips_to_migrate.
-        dst_targs = g_malloc0(sizeof(struct ct_events_targs));
-        dst_targs->targets = targets;
-        dst_targs->stop_flag = stop_flag;
-        dst_targs->is_src = false;
-        ret = pthread_create(&dst_targs->tid, NULL,
-                             &pthread_wrapper_ct_events,
-                             (void *)dst_targs);
-        if (ret != 0) {
-            LOG(ERROR, "%s: dst events thread creation failed. %s", __func__,
-                strerror(ret));
-            return -1;
-        }
-        ret = pthread_setname_np(dst_targs->tid, "ct_events_dst");
-        if (ret != 0) {
-            LOG(WARNING, "%s: Failed to set thread name \"ct_events_dst\". %s",
-                __func__, strerror(ret));
-        }
-
-        // Get all the conntrack entries for the given ip address.
-        dump_conntrack(targets);
-
-        // Wait for all the threads to be stopped.
-        pthread_join(src_targs->tid, NULL);
-        pthread_join(dst_targs->tid, NULL);
-        pthread_join(ct_del_args.tid, NULL);
-
-        g_free(src_targs);
-        g_free(dst_targs);
-
+        num_entries = g_hash_table_size(targets->ips_to_migrate);
     } else {
-
-         /* SAVE_INPUT_PORT_ZONES */
-        uint32_t num_zones = g_hash_table_size(targets->zones_to_migrate);
-
-        if (num_zones == 0) {
-            LOG(INFO, "%s: Not starting any save mode threads since number "
-                "of zones is 0", __func__);
-            return 0;
-        }
-
-        // Wire up the delete-thread state for zone mode.
-        // NOTE: ct_del_args is an extern global variable
-        ct_del_args.kind           = SAVE_INPUT_PORT_ZONES;
-        ct_del_args.zones_migrated = targets->zones_to_migrate;
-
-        // Conntrack delete thread (mode-aware: dispatches on
-        // ct_del_args.kind when on_clear wakes it up).
-        ret = pthread_create(&ct_del_args.tid, NULL,
-                             &delete_ct_entries,
-                             (void *)&ct_del_args);
-        if (ret != 0) {
-            LOG(ERROR, "%s: CT delete thread creation failed. %s", __func__,
-                strerror(ret));
-            return -1;
-        }
-        ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
-        if (ret != 0) {
-            LOG(WARNING, "%s: Failed to set thread name \"ct_delete\": %s",
-                __func__, strerror(ret));
-        }
-
-        // BPF can't filter on CT zone, so we don't split src/dst threads.
-        // One unfiltered events thread is enough; the callback does the
-        // zone match in-process.
-        zone_targs = g_malloc0(sizeof(struct ct_events_targs));
-        zone_targs->targets = targets;
-        zone_targs->stop_flag = stop_flag;
-        zone_targs->is_src = false;   /* unused in zone mode */
-        ret = pthread_create(&zone_targs->tid, NULL,
-                             &pthread_wrapper_ct_events,
-                             (void *)zone_targs);
-        if (ret != 0) {
-            LOG(ERROR, "%s: zone events thread creation failed. %s", __func__,
-                strerror(ret));
-            return -1;
-        }
-        ret = pthread_setname_np(zone_targs->tid, "ct_events_zone");
-        if (ret != 0) {
-            LOG(WARNING, "%s: Failed to set thread name \"ct_events_zone\". "
-                "%s", __func__, strerror(ret));
-        }
-
-        // Get all the conntrack entries for the given zones.
-        dump_conntrack(targets);
-
-        // Wait for the events thread, then the delete thread. Same order
-        // as the IP branch above.
-        pthread_join(zone_targs->tid, NULL);
-        pthread_join(ct_del_args.tid, NULL);
-
-        g_free(zone_targs);
-
+        num_entries = g_hash_table_size(targets->zones_to_migrate);
+    }
+    if (num_entries == 0) {
+        LOG(INFO, "%s: No entries to migrate (kind=%s); skipping save "
+            "mode threads", __func__,
+            save_input_kind_to_string(targets->kind));
+        return 0;
+    }
+    /* IP-only: BPF filter cap. Zone mode does in-callback matching so
+     * the per-IP limit does not apply. */
+    if (targets->kind == SAVE_INPUT_IPS &&
+        num_entries > MAX_IP_ADDRESSES_SUPPORTED) {
+        LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
+            "No Conntrack Migration will be performed.",
+            MAX_IP_ADDRESSES_SUPPORTED);
+        return 0;
     }
 
+    /* Common: wire up the delete-thread state, then create the thread.
+     * The delete thread is started in BOTH modes; the body of
+     * _delete_ct_entries dispatches on kind when on_clear wakes it up.
+     * NOTE: ct_del_args is an extern global. */
+    ct_del_args.kind = targets->kind;
+    if (targets->kind == SAVE_INPUT_IPS) {
+        ct_del_args.ips_migrated = targets->ips_to_migrate;
+    } else {
+        ct_del_args.zones_migrated = targets->zones_to_migrate;
+    }
+    if (create_delete_thread() != 0) {
+        return -1;
+    }
+
+    /* Mode-specific: create the events thread(s). IP mode runs two
+     * BPF-filtered threads (src + dst). Zone mode runs one unfiltered
+     * thread; the callback handles zone matching in-process because
+     * BPF cannot filter on CT zone. */
+    if (targets->kind == SAVE_INPUT_IPS) {
+        if (create_events_thread(targets, stop_flag, true,
+                                 "ct_events_src", &src_targs) != 0) {
+            goto cleanup_delete_thread;
+        }
+        if (create_events_thread(targets, stop_flag, false,
+                                 "ct_events_dst", &dst_targs) != 0) {
+            goto cleanup_delete_thread;
+        }
+    } else {
+        if (create_events_thread(targets, stop_flag, false,
+                                 "ct_events_zone", &zone_targs) != 0) {
+            goto cleanup_delete_thread;
+        }
+    }
+
+    /* Common: dump live entries, then join events thread(s) + delete
+     * thread in that order so on_clear can drive the shutdown. */
+    dump_conntrack(targets);
+
+    if (targets->kind == SAVE_INPUT_IPS) {
+        pthread_join(src_targs->tid, NULL);
+        pthread_join(dst_targs->tid, NULL);
+        g_free(src_targs);
+        g_free(dst_targs);
+    } else {
+        pthread_join(zone_targs->tid, NULL);
+        g_free(zone_targs);
+    }
+    pthread_join(ct_del_args.tid, NULL);
     return 0;
+
+cleanup_delete_thread:
+    /* Events thread creation failed after the delete thread was
+     * already started. Wake the delete thread with a sentinel clear
+     * so it doesn't block on clear_called_cond forever, join it, then
+     * free any partial events-thread allocations (NULL-safe). */
+    pthread_mutex_lock(&ct_del_args.mutex);
+    ct_del_args.clear_called = true;
+    pthread_cond_signal(&ct_del_args.clear_called_cond);
+    pthread_mutex_unlock(&ct_del_args.mutex);
+    pthread_join(ct_del_args.tid, NULL);
+    g_free(src_targs);
+    g_free(dst_targs);
+    g_free(zone_targs);
+    return -1;
 }
 
 /**
@@ -456,6 +472,17 @@ create_zones_ht_from_args(char *argv[], int n_entries)
     const char **zones;
     GHashTable *ht;
     const int old_zone_offset = 1;
+   
+    if (n_entries <= 0) {
+        LOG(ERROR, "%s: non-positive n_entries (%d)", __func__, n_entries);
+        return NULL;
+    }
+
+    if (argv == NULL) {
+        LOG(ERROR, "%s: argv is NULL", __func__);
+        return NULL;
+    }
+
 
     zones = g_malloc0(sizeof(*zones) * n_entries);
     for (i = 0; i < n_entries; i++) {
@@ -508,6 +535,11 @@ build_zone_remap_from_args(char *argv[], int n_entries)
 
     if (n_entries <= 0) {
         LOG(ERROR, "%s: non-positive n_entries (%d)", __func__, n_entries);
+        return NULL;
+    }
+
+    if (argv == NULL) {
+        LOG(ERROR, "%s: argv is NULL there are no port-zone remap entries", __func__);
         return NULL;
     }
 
@@ -784,6 +816,11 @@ dmain(int argc, char *argv[], const struct cli_mode_config *cli)
                 goto cleanup;
             }
             dbus_server_args.load_targets = load_targets_new_from_remap(remap);
+            if (dbus_server_args.load_targets == NULL) {
+                LOG(ERROR, "%s: failed to create load_targets", __func__);
+                rc = EINVAL;
+                goto cleanup;
+            }
             LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
                 __func__, cli->num_entries);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -23,12 +23,22 @@
  * capability.
  *
  * Usage:
- *  - SAVE mode: DBUS_SESSION_BUS_ADDRESS=<dbus address> conntrack_migrator 2 <dbus_helper_id> <num_ip_addresses> <space separated ip address list>
- *  - LOAD mode: DBUS_SESSION_BUS_ADDRESS=<dbus address> conntrack_migrator 1 <dbus_helper_id>
+ *  Two CLI shapes are supported. The legacy IP-based form is preserved as-is
+ *  so existing callers keep working; the new port/CT-zone form is selected
+ *  automatically based on the ratio of trailing args to the declared count.
  *
- *  eg:
- *  - SAVE mode: DBUS_SESSION_BUS_ADDRESS=unix:abstract=/abc,guid=def conntrack_migrator 2 helper1 2 1.1.1.1 2.2.2.2
- *  - LOAD mode: DBUS_SESSION_BUS_ADDRESS=unix:abstract=/abc,guid=def conntrack_migrator 1 helper1
+ *  Legacy IP-based:
+ *    - SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 \
+ *            <helper_id> <num_ips> <ip1> <ip2> ...
+ *    - LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 <helper_id>
+ *
+ *  New port/CT-zone-based:
+ *    - SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 \
+ *            <helper_id> <N> <port_uuid_1> <old_ct_zone_1> ... \
+ *                              <port_uuid_N> <old_ct_zone_N>
+ *    - LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 \
+ *            <helper_id> <N> <port_uuid_1> <old_ct_zone_1> <new_ct_zone_1> \
+ *                          ... <port_uuid_N> <old_ct_zone_N> <new_ct_zone_N>
  */
 
 #define _GNU_SOURCE
@@ -36,6 +46,7 @@
 #include <err.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -55,12 +66,57 @@
 #include "lmct_config.h"
 #include "log.h"
 
-#define MODE_ARG_INDEX 1
-#define HELPER_ID_ARG_INDEX 2
-#define NUM_IP_ADDR_ARG_INDEX 3
-#define IP_ADDR_LIST_ARG_INDEX 4
+#define MODE_ARG_INDEX                  1
+#define HELPER_ID_ARG_INDEX             2
 
-#define MAX_IP_ADDRESSES_SUPPORTED 127
+/* Legacy (IP-mode) names kept for backward compat with existing code. */
+#define NUM_IP_ADDR_ARG_INDEX           3
+#define IP_ADDR_LIST_ARG_INDEX          4
+
+/* Generic names that read cleanly for both IP and port-zone layouts. */
+#define NUM_ENTRIES_ARG_INDEX           3
+#define ENTRIES_LIST_START_ARG_INDEX    4
+
+/* Per-entry argv stride for the new (port_uuid, ct_zone[, new_ct_zone]) layout. */
+#define SAVE_PORT_ZONE_STRIDE           2   /* <port_uuid> <old_ct_zone> */
+#define LOAD_PORT_ZONE_STRIDE           3   /* <port_uuid> <old_ct_zone> <new_ct_zone> */
+
+/* Canonical UUID hex string length: 8-4-4-4-12 = 36 chars. */
+#define UUID_STRING_LEN                 36
+
+#define MAX_IP_ADDRESSES_SUPPORTED      127
+
+/**
+ * Sub-mode tag: tells the rest of the daemon which SAVE-mode CLI layout
+ * was detected from argv.
+ */
+enum save_input_kind {
+    SAVE_INPUT_IPS,
+    SAVE_INPUT_PORT_ZONES
+};
+
+/**
+ * Sub-mode tag: tells the rest of the daemon which LOAD-mode CLI layout
+ * was detected from argv.
+ */
+enum load_input_kind {
+    LOAD_INPUT_LEGACY,
+    LOAD_INPUT_PORT_ZONES
+};
+
+/**
+ * Result of CLI parsing - filled by check_args() and consumed by main().
+ *
+ * The sub-kind field is a tagged union: the active arm is determined by
+ * @mode (SAVE_MODE -> save_kind, LOAD_MODE -> load_kind).
+ */
+struct parsed_cli {
+    enum op_mode mode;
+    union {
+        enum save_input_kind save_kind;
+        enum load_input_kind load_kind;
+    };
+};
 
 const char *lmct_config_path = "/etc/lmct_config";
 
@@ -298,6 +354,61 @@ create_ips_ht_from_args(char *argv[])
 }
 
 /**
+ * Decides which SAVE-mode CLI layout we are looking at by comparing the
+ * number of trailing argv slots against the declared entry count N:
+ *
+ *   ratio = (argc - ENTRIES_LIST_START_ARG_INDEX) / N
+ *     ratio == 1 -> SAVE_INPUT_IPS         (one IP per entry)
+ *     ratio == 2 -> SAVE_INPUT_PORT_ZONES  (port_uuid + old_zone per entry)
+ *
+ * The "no list / N == 0" cases default to SAVE_INPUT_IPS so the existing
+ * "VM with no IPv4 NICs" passthrough in start_in_save_mode() stays intact.
+ *
+ * NOTE: this lives in the runtime (post-fork) section of the file, above
+ * dmain(), because dmain re-runs the detection after the double fork to
+ * recover the SAVE sub-kind without threading it through a new parameter.
+ * The pre-fork validator block below uses the same function for shape
+ * checking; we deliberately keep one definition shared by both call sites.
+ *
+ * Args:
+ *   @argc num of CLI arguments.
+ *   @argv array of CLI arguments.
+ *
+ * Returns:
+ *   The detected sub-mode. Aborts the process via errx() on a shape
+ *   mismatch (declared N is non-zero but trailing args fit neither layout).
+ */
+static enum save_input_kind
+detect_save_input_kind(int argc, char *argv[])
+{
+    int n;
+    int remaining;
+
+    if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
+        return SAVE_INPUT_IPS;
+    }
+
+    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    if (n <= 0) {
+        return SAVE_INPUT_IPS;
+    }
+
+    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
+
+    if (remaining == n * 1) {
+        return SAVE_INPUT_IPS;
+    }
+    if (remaining == n * SAVE_PORT_ZONE_STRIDE) {
+        return SAVE_INPUT_PORT_ZONES;
+    }
+
+    errx(EXIT_FAILURE,
+         "SAVE mode: argv shape mismatch. N=%d, expected %d args (IP form) "
+         "or %d args (port-zone form), got %d.",
+         n, n * 1, n * SAVE_PORT_ZONE_STRIDE, remaining);
+}
+
+/**
  * Entry point for the daemon.
  *
  * Args:
@@ -316,10 +427,18 @@ dmain(int argc, char *argv[])
     int ret;
     bool stop_flag = false;
     struct dbus_targs dbus_server_args;
+    enum save_input_kind save_kind = SAVE_INPUT_IPS;
 
-    // Parse the command line argmuments.
+    // Parse the command line arguments.
     mode = atoi(argv[MODE_ARG_INDEX]);
     helper_id = argv[HELPER_ID_ARG_INDEX];
+
+    // Re-detect the SAVE sub-kind here because the parent's parsed_cli
+    // lived on a stack frame that is gone after the double fork. argv
+    // is preserved across forks, so detection is cheap and side-effect-free.
+    if (mode == SAVE_MODE) {
+        save_kind = detect_save_input_kind(argc, argv);
+    }
 
     // Initialise logging at default INFO level.
     ret = init_log(INFO, helper_id);
@@ -367,16 +486,24 @@ dmain(int argc, char *argv[])
 
     // Start save mode threads.
     if (mode == SAVE_MODE) {
-        GHashTable *ips_to_migrate;
-        ips_to_migrate = create_ips_ht_from_args(argv);
-        if (ips_to_migrate == NULL) {
-            return EINVAL;
-        }
+        if (save_kind == SAVE_INPUT_IPS) {
+            GHashTable *ips_to_migrate;
+            ips_to_migrate = create_ips_ht_from_args(argv);
+            if (ips_to_migrate == NULL) {
+                return EINVAL;
+            }
 
-        ret = start_in_save_mode(ips_to_migrate, &stop_flag);
-        g_hash_table_destroy(ips_to_migrate);
-        if (ret != 0) {
-            return EAGAIN;
+            ret = start_in_save_mode(ips_to_migrate, &stop_flag);
+            g_hash_table_destroy(ips_to_migrate);
+            if (ret != 0) {
+                return EAGAIN;
+            }
+        } else {
+            // PORT_ZONES SAVE path. Wired up in Step 2: it will build a
+            // (zones_to_migrate, ports_to_migrate) bundle from argv and
+            // hand it to a zone-aware start_in_save_mode().
+            LOG(INFO, "%s: PORT_ZONES SAVE path - "
+                "to be implemented in Step 2", __func__);
         }
     }
 
@@ -387,17 +514,155 @@ dmain(int argc, char *argv[])
     return 0;
 }
 
+/**
+ * Validates that @s is a canonical 8-4-4-4-12 hex UUID string.
+ *
+ * No version/variant bit checks - any 36-char hex-with-hyphens string
+ * is accepted. This is intentionally permissive: callers (e.g. libvirt)
+ * pass UUIDs in canonical form and we only need to reject obvious junk.
+ *
+ * Args:
+ *   @s nul-terminated candidate string. May be NULL.
+ *
+ * Returns:
+ *   true if the string is well-formed, false otherwise.
+ */
+static bool
+is_valid_uuid_string(const char *s)
+{
+    int i;
+
+    if (s == NULL || strlen(s) != UUID_STRING_LEN) {
+        return false;
+    }
+
+    for (i = 0; i < UUID_STRING_LEN; i++) {
+        char c = s[i];
+
+        if (i == 8 || i == 13 || i == 18 || i == 23) {
+            if (c != '-') {
+                return false;
+            }
+        } else {
+            bool is_hex = (c >= '0' && c <= '9') ||
+                          (c >= 'a' && c <= 'f') ||
+                          (c >= 'A' && c <= 'F');
+            if (!is_hex) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Strict parser for a CT zone: must be a complete decimal uint16 with no
+ * trailing junk, no whitespace, no overflow.
+ *
+ * Uses the standard out-parameter pattern: @out is only written on success.
+ * On failure the caller's storage is left untouched.
+ *
+ * Args:
+ *   @s   nul-terminated decimal string.
+ *   @out output uint16_t (only written on success). Must be non-NULL.
+ *
+ * Returns:
+ *   true on success, false otherwise.
+ */
+static bool
+parse_ct_zone(const char *s, uint16_t *out)
+{
+    char *end = NULL;
+    unsigned long v;
+
+    if (s == NULL || *s == '\0' || out == NULL) {
+        return false;
+    }
+
+    errno = 0;
+    v = strtoul(s, &end, 10);
+    if (errno != 0 || end == s || *end != '\0' || v > UINT16_MAX) {
+        return false;
+    }
+
+    *out = (uint16_t) v;
+    return true;
+}
+
+/**
+ * Decides which LOAD-mode CLI layout we are looking at.
+ *
+ * Legacy LOAD is strictly: `conntrack_migrator 1 <helper_id>` (argc == 3).
+ * New LOAD is:             `conntrack_migrator 1 <helper_id> <N>
+ *                              <port_uuid> <old_ct_zone> <new_ct_zone> ...`
+ *                          (argc == 4 + 3*N).
+ *
+ * Anything else is a hard error - we deliberately do NOT silently fall back
+ * to legacy if the trailing args do not match the new shape.
+ *
+ * Args:
+ *   @argc num of CLI arguments.
+ *   @argv array of CLI arguments.
+ *
+ * Returns:
+ *   The detected sub-mode. Aborts the process via errx() on any mismatch.
+ */
+static enum load_input_kind
+detect_load_input_kind(int argc, char *argv[])
+{
+    int n;
+    int remaining;
+
+    if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
+        return LOAD_INPUT_LEGACY;
+    }
+
+    if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
+        errx(EXIT_FAILURE,
+             "LOAD mode: trailing args present but no port-zone list. "
+             "Expected `conntrack_migrator 1 <helper_id>` or "
+             "`conntrack_migrator 1 <helper_id> <N> "
+             "<port_uuid> <old_zone> <new_zone> ...`.");
+    }
+
+    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    if (n <= 0) {
+        errx(EXIT_FAILURE,
+             "LOAD mode: invalid number of port-zone entries: '%s' "
+             "(must be a positive integer).",
+             argv[NUM_ENTRIES_ARG_INDEX]);
+    }
+
+    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
+
+    if (remaining == n * LOAD_PORT_ZONE_STRIDE) {
+        return LOAD_INPUT_PORT_ZONES;
+    }
+
+    errx(EXIT_FAILURE,
+         "LOAD mode: argv shape mismatch. N=%d, expected %d args "
+         "(port-zone form), got %d.",
+         n, n * LOAD_PORT_ZONE_STRIDE, remaining);
+}
+
 static void
 err_usage(void)
 {
     errx(EXIT_FAILURE,
         "Usage:\n"
-        "SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<dbus address> "
-        "conntrack_migrator 2 <dbus_helper_id> <num_ip_addresses> "
-        "<space separated ip address list>\n"
-        "LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<dbus address> "
-        "conntrack_migrator 1 <dbus_helper_id>\n"
-        "NOTE: DBUS_SYSTEM_BUS_ADDRESS env variable should be set.\n");
+        "  Legacy IP-based:\n"
+        "    SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 "
+            "<helper_id> <num_ips> <ip1> <ip2> ...\n"
+        "    LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 "
+            "<helper_id>\n"
+        "  Port/CT-zone-based:\n"
+        "    SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 "
+            "<helper_id> <N> <port_uuid_1> <old_ct_zone_1> ... "
+            "<port_uuid_N> <old_ct_zone_N>\n"
+        "    LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 "
+            "<helper_id> <N> <port_uuid_1> <old_ct_zone_1> <new_ct_zone_1> "
+            "... <port_uuid_N> <old_ct_zone_N> <new_ct_zone_N>\n"
+        "NOTE: DBUS_SYSTEM_BUS_ADDRESS env variable must be set.\n");
 }
 
 /**
@@ -429,23 +694,22 @@ check_dbus_address_env(void)
 }
 
 /**
- * Performs checks on args when started in save mode.
+ * Performs checks on args when started in save mode (legacy IP form).
  *
  * Checks performed:
- * 1. Num of ip address param is present and is non-negative
- * 2. The ip address list size is num of ip address provided
- * 3. Number of ip addresses does not exceed 127 which is the limit set by
- *    netlink bsd filters.
+ * 1. Num of ip address param is present and is non-negative.
+ * 2. The ip address list size matches the num of ip addresses provided.
+ *
+ * NOTE: this is the legacy SAVE validator, kept verbatim from the original
+ * implementation. The 127-IP cap referenced in the original docstring is
+ * enforced later in start_in_save_mode().
  *
  * Args:
- *   @argc num of arguemnts
+ *   @argc num of arguments.
  *   @argv array of CLI arguments.
- *
- * Returns:
- *   true if success, false otherwise.
  */
 static void
-check_save_mode_args(int argc, char *argv[])
+check_ip_save_args(int argc, char *argv[])
 {
     int num_ip_addr;
 
@@ -460,19 +724,177 @@ check_save_mode_args(int argc, char *argv[])
 }
 
 /**
- * Performs checks on CLI args.
+ * Per-entry content checks for the new SAVE port-zone layout.
  *
- * Checks performed:
- * 1. Mode is vaild
- * 2. DBUS_SYSTEM_BUS_ADDRESS env is set
- * 3. SAVE mode has proper arguments
+ * Arity (argc vs declared N) is guaranteed by detect_save_input_kind()
+ * before we get here, so we only validate the *content* of each entry:
+ *  - port_uuid is a canonical 8-4-4-4-12 hex UUID,
+ *  - old_ct_zone parses cleanly as uint16.
+ *
+ * Aborts the process via errx() on the first malformed entry.
  *
  * Args:
- *   @argc num of arguemnts
+ *   @argc num of arguments (used only for an arity sanity check).
  *   @argv array of CLI arguments.
  */
 static void
-check_args(int argc, char *argv[])
+check_zone_save_args(int argc, char *argv[])
+{
+    int n;
+    int i;
+
+    (void) argc;   /* arity already checked by the detector */
+
+    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+
+    for (i = 0; i < n; i++) {
+        int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
+        const char *port_uuid = argv[base];
+        const char *zone_str  = argv[base + 1];
+        uint16_t zone_val;
+
+        if (!is_valid_uuid_string(port_uuid)) {
+            errx(EXIT_FAILURE,
+                 "Invalid UUID at port-zone entry %d: '%s'",
+                 i, port_uuid);
+        }
+        if (!parse_ct_zone(zone_str, &zone_val)) {
+            errx(EXIT_FAILURE,
+                 "Invalid old_ct_zone at port-zone entry %d: '%s' "
+                 "(must be uint16)", i, zone_str);
+        }
+    }
+}
+
+/**
+ * Per-entry content checks for the new LOAD port-zone layout.
+ *
+ * Arity is guaranteed by detect_load_input_kind(); we only validate the
+ * content of each (port_uuid, old_ct_zone, new_ct_zone) triple.
+ *
+ * Args:
+ *   @argc num of arguments (used only for an arity sanity check).
+ *   @argv array of CLI arguments.
+ */
+static void
+check_zone_load_args(int argc, char *argv[])
+{
+    int n;
+    int i;
+
+    (void) argc;
+
+    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+
+    for (i = 0; i < n; i++) {
+        int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
+        const char *port_uuid    = argv[base];
+        const char *old_zone_str = argv[base + 1];
+        const char *new_zone_str = argv[base + 2];
+        uint16_t z;
+
+        if (!is_valid_uuid_string(port_uuid)) {
+            errx(EXIT_FAILURE,
+                 "Invalid UUID at port-zone entry %d: '%s'",
+                 i, port_uuid);
+        }
+        if (!parse_ct_zone(old_zone_str, &z)) {
+            errx(EXIT_FAILURE,
+                 "Invalid old_ct_zone at port-zone entry %d: '%s'",
+                 i, old_zone_str);
+        }
+        if (!parse_ct_zone(new_zone_str, &z)) {
+            errx(EXIT_FAILURE,
+                 "Invalid new_ct_zone at port-zone entry %d: '%s'",
+                 i, new_zone_str);
+        }
+    }
+}
+
+/**
+ * Top-level SAVE-mode arg dispatcher.
+ *
+ * Picks IP vs port-zone via detect_save_input_kind() and delegates
+ * per-entry validation to the appropriate validator. Reports the
+ * detected sub-kind to the caller via @out_kind.
+ *
+ * Args:
+ *   @argc     num of arguments.
+ *   @argv     array of CLI arguments.
+ *   @out_kind output pointer for the detected sub-kind. May be NULL.
+ */
+static void
+check_save_mode_args(int argc, char *argv[],
+                     enum save_input_kind *out_kind)
+{
+    enum save_input_kind kind = detect_save_input_kind(argc, argv);
+
+    if (kind == SAVE_INPUT_IPS) {
+        check_ip_save_args(argc, argv);
+    } else {
+        if(kind == SAVE_INPUT_PORT_ZONES) {
+            check_zone_save_args(argc, argv);
+        } else {
+            errx(EXIT_FAILURE, "Invalid save input kind: %d", kind);
+        }
+    }
+
+    if (out_kind != NULL) {
+        *out_kind = kind;
+    }
+}
+
+/**
+ * Top-level LOAD-mode arg dispatcher.
+ *
+ * Legacy LOAD takes no extra args beyond <mode> <helper_id>; the new LOAD
+ * port-zone layout is content-validated. Reports the detected sub-kind
+ * to the caller via @out_kind.
+ *
+ * Args:
+ *   @argc     num of arguments.
+ *   @argv     array of CLI arguments.
+ *   @out_kind output pointer for the detected sub-kind. May be NULL.
+ */
+static void
+check_load_mode_args(int argc, char *argv[],
+                     enum load_input_kind *out_kind)
+{
+    enum load_input_kind kind = detect_load_input_kind(argc, argv);
+
+    if (kind == LOAD_INPUT_PORT_ZONES) {
+        check_zone_load_args(argc, argv);
+    }else{
+        if(kind != LOAD_INPUT_LEGACY) {
+            errx(EXIT_FAILURE, "Invalid load input kind: %d", kind);
+        }
+    }
+
+    if (out_kind != NULL) {
+        *out_kind = kind;
+    }
+}
+
+/**
+ * Top-level CLI validation entry point.
+ *
+ * Checks performed:
+ * 1. Minimum argc.
+ * 2. DBUS_SYSTEM_BUS_ADDRESS env is set.
+ * 3. Mode is valid (LOAD/SAVE).
+ * 4. Per-mode argument shape and per-entry content (legacy IP form or
+ *    new port-zone form, auto-detected from argv).
+ *
+ * On success populates @out with the validated (mode, sub-kind) pair.
+ * On any failure errx() exits the process.
+ *
+ * Args:
+ *   @argc num of arguments.
+ *   @argv array of CLI arguments.
+ *   @out  output struct populated with the parse result. Must be non-NULL.
+ */
+static void
+check_args(int argc, char *argv[], struct parsed_cli *out)
 {
     int mode;
 
@@ -484,9 +906,12 @@ check_args(int argc, char *argv[])
 
     mode = atoi(argv[MODE_ARG_INDEX]);
     check_mode(mode);
+    out->mode = (enum op_mode) mode;
 
     if (mode == SAVE_MODE) {
-        check_save_mode_args(argc, argv);
+        check_save_mode_args(argc, argv, &out->save_kind);
+    } else {
+        check_load_mode_args(argc, argv, &out->load_kind);
     }
 }
 
@@ -517,9 +942,12 @@ int
 main(int argc, char *argv[])
 {
     int child_pid;
+    struct parsed_cli cli = {0};
 
-    // Perform prechecks on the arguments
-    check_args(argc, argv);
+    // Validate CLI args + decide IP-vs-zone sub-kind before any forks.
+    // The result is recomputed inside dmain() because the parent's stack
+    // (and thus this `cli`) is gone by the time the grandchild runs.
+    check_args(argc, argv, &cli);
 
     // Fork child
     child_pid = fork();
@@ -529,7 +957,7 @@ main(int argc, char *argv[])
     if (child_pid == 0) {
         // Become a process group and session group leader
         setsid();
-
+        
         // Fork granchild so that session leader can exit
         int grandchild_pid = fork();
         if (grandchild_pid < 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -772,7 +772,8 @@ check_ip_save_args(int argc, char *argv[])
  *
  * Arity (argc vs declared N) is guaranteed by detect_save_input_kind()
  * before we get here, so we only validate the *content* of each entry:
- *  - port_uuid is a canonical 8-4-4-4-12 hex UUID,
+ *  - port_uuid is a port-prefixed canonical UUID of the form
+ *    "port_<8-4-4-4-12>" (total length 41),
  *  - old_ct_zone parses cleanly as uint16.
  *
  * Aborts the process via errx() on the first malformed entry.

--- a/src/main.c
+++ b/src/main.c
@@ -41,72 +41,76 @@
  *                          ... <port_uuid_N> <old_ct_zone_N> <new_ct_zone_N>
  */
 
-#define _GNU_SOURCE
+ #define _GNU_SOURCE
 
-#include <err.h>
-#include <errno.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
-#include <glib.h>
-#include <libmnl/libmnl.h>
-#include <pthread.h>
-
-#include "common.h"
-#include "conntrack.h"
-#include "conntrack_store.h"
-#include "ct_delete_args.h"
-#include "dbus_server.h"
-#include "lmct_config.h"
-#include "log.h"
-
-#define MODE_ARG_INDEX                  1
-#define HELPER_ID_ARG_INDEX             2
-
-/* Legacy (IP-mode) names kept for backward compat with existing code. */
-#define NUM_IP_ADDR_ARG_INDEX           3
-#define IP_ADDR_LIST_ARG_INDEX          4
-
-/* Generic names that read cleanly for both IP and port-zone layouts. */
-#define NUM_ENTRIES_ARG_INDEX           3
-#define ENTRIES_LIST_START_ARG_INDEX    4
-
-/* Per-entry argv stride for the new (port_uuid, ct_zone[, new_ct_zone]) layout. */
+ #include <err.h>
+ #include <errno.h>
+ #include <stdbool.h>
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <unistd.h>
+ 
+ #include <glib.h>
+ #include <libmnl/libmnl.h>
+ #include <pthread.h>
+ 
+ #include "common.h"
+ #include "conntrack.h"
+ #include "conntrack_store.h"
+ #include "ct_delete_args.h"
+ #include "dbus_server.h"
+ #include "lmct_config.h"
+ #include "log.h"
+ 
+ #define MODE_ARG_INDEX                  1
+ #define HELPER_ID_ARG_INDEX             2
+ 
+ /* Legacy (IP-mode) names kept for backward compat with existing code. */
+ #define NUM_IP_ADDR_ARG_INDEX           3
+ #define IP_ADDR_LIST_ARG_INDEX          4
+ 
+ /* Generic names that read cleanly for both IP and port-zone layouts. */
+ #define NUM_ENTRIES_ARG_INDEX           3
+ #define ENTRIES_LIST_START_ARG_INDEX    4
+ 
+/* Per-entry argv stride for the legacy IP layout and the new
+ * (port_uuid, ct_zone[, new_ct_zone]) layout. IP_STRIDE is named (not
+ * inlined as 1) so detect_save_input_kind() reads symmetrically against
+ * its port-zone peer and the shape-mismatch error message is self-explanatory. */
+#define IP_STRIDE                       1   /* <ip> */
 #define SAVE_PORT_ZONE_STRIDE           2   /* <port_uuid> <old_ct_zone> */
 #define LOAD_PORT_ZONE_STRIDE           3   /* <port_uuid> <old_ct_zone> <new_ct_zone> */
-
-#define MAX_IP_ADDRESSES_SUPPORTED      127
-
-/**
- * Result of CLI parsing - filled by check_args() pre-fork and consumed
- * by dmain() post-fork. Threading the parsed result through avoids
- * re-walking argv inside the daemon: fork() copies the entire address
- * space (including main's stack frame), so the struct is valid in the
- * grandchild and is read verbatim.
- *
- * The sub-kind field is a tagged union: the active arm is determined by
- * @mode (SAVE_MODE -> save_kind, LOAD_MODE -> load_kind).
- *
- * @num_entries holds the declared entry count from
- * argv[NUM_ENTRIES_ARG_INDEX] when applicable:
- *   - SAVE IP-mode "no IPv4 NICs" path  (argc <= 4):  0
- *   - SAVE IP-mode standard:                          num_ips
- *   - SAVE port-zone mode:                            N
- *   - LOAD legacy:                                    0
- *   - LOAD port-zone mode:                            N
- * Consumers that legitimately accept 0 (the no-IPv4-NICs path) must
- * treat 0 as "list absent" rather than "list empty bad".
- *
- * num_entries is captured by detect_*_input_kind during its existing
- * shape-detection parse and propagated up through check_*_mode_args -
- * check_args does not parse argv[3] a second time.
- */
+ 
+ #define MAX_IP_ADDRESSES_SUPPORTED      127
+ 
+ /**
+  * Result of CLI parsing - filled by check_args() pre-fork and consumed
+  * by dmain() post-fork. Threading the parsed result through avoids
+  * re-walking argv inside the daemon: fork() copies the entire address
+  * space (including main's stack frame), so the struct is valid in the
+  * grandchild and is read verbatim.
+  *
+  * The sub-kind field is a tagged union: the active arm is determined by
+  * @mode (SAVE_MODE -> save_kind, LOAD_MODE -> load_kind).
+  *
+  * @num_entries holds the declared entry count from
+  * argv[NUM_ENTRIES_ARG_INDEX] when applicable:
+  *   - SAVE IP-mode "no IPv4 NICs" path  (argc <= 4):  0
+  *   - SAVE IP-mode standard:                          num_ips
+  *   - SAVE port-zone mode:                            N
+  *   - LOAD legacy:                                    0
+  *   - LOAD port-zone mode:                            N
+  * Consumers that legitimately accept 0 (the no-IPv4-NICs path) must
+  * treat 0 as "list absent" rather than "list empty bad".
+  *
+  * num_entries is captured by detect_*_input_kind during its existing
+  * shape-detection parse and propagated up through check_*_mode_args -
+  * check_args does not parse argv[3] a second time.
+  */
 struct cli_mode_config {
     enum op_mode mode;
     union {
@@ -114,451 +118,917 @@ struct cli_mode_config {
         enum load_input_kind load_kind;
     };
     int num_entries;
+    /* LOAD-port-zone mode only: (old_zone -> new_zone) remap built in
+     * check_zone_load_args() during pre-fork validation, consumed in
+     * dmain() after the double fork. NULL for SAVE mode and for
+     * LOAD-legacy mode. Ownership transfers to load_targets_new_from_remap();
+     * the wrapped bundle is destroyed by load_targets_destroy() at dmain
+     * cleanup time. */
+    GHashTable *zone_remap;
 };
-
-const char *lmct_config_path = "/etc/lmct_config";
-
-// Mode number to string
-const char *mode_to_string[] = {
-    [LOAD_MODE] = "LOAD",
-    [SAVE_MODE] = "SAVE"
-};
-
-struct ct_delete_args ct_del_args = {
-    .kind = SAVE_INPUT_IPS,       /* overwritten in start_in_save_mode */
-    /* Only the active union arm is named; the other arm overlays the
-     * same memory and is zero-initialised by the {0} default. Naming
-     * both arms here would trip -Woverride-init. */
-    .ips_migrated = NULL,
-    .ips_on_host = NULL,
-    .clear_called = false,
-    .mutex = PTHREAD_MUTEX_INITIALIZER,
-    .clear_called_cond = PTHREAD_COND_INITIALIZER
-};
-
-/**
- * Wrapper for listening for CT events based on the filter on src/dst field in
- * the CT entries.
- *
- * Args:
- *   @data user data provided to the function. Here it's of type ct_events_targs
- * Returns:
- *   NULL
- */
-static void *
-pthread_wrapper_ct_events(void *data)
-{
-    struct ct_events_targs *targs;
-    struct mnl_socket *nl;
-
+ 
+ const char *lmct_config_path = "/etc/lmct_config";
+ 
+ // Mode number to string
+ const char *mode_to_string[] = {
+     [LOAD_MODE] = "LOAD",
+     [SAVE_MODE] = "SAVE"
+ };
+ 
+ struct ct_delete_args ct_del_args = {
+     .kind = SAVE_INPUT_IPS,       /* overwritten in start_in_save_mode */
+     /* Only the active union arm is named; the other arm overlays the
+      * same memory and is zero-initialised by the {0} default. Naming
+      * both arms here would trip -Woverride-init. */
+     .ips_migrated = NULL,
+     .ips_on_host = NULL,
+     .clear_called = false,
+     .mutex = PTHREAD_MUTEX_INITIALIZER,
+     .clear_called_cond = PTHREAD_COND_INITIALIZER
+ };
+ 
+ /**
+  * Wrapper for listening for CT events based on the filter on src/dst field in
+  * the CT entries.
+  *
+  * Args:
+  *   @data user data provided to the function. Here it's of type ct_events_targs
+  * Returns:
+  *   NULL
+  */
+ static void *
+ pthread_wrapper_ct_events(void *data)
+ {
+     struct ct_events_targs *targs;
+     struct mnl_socket *nl;
+ 
     targs = (struct ct_events_targs *) data;
-    LOG(INFO, "%s: Starting conntrack events thread. is_src = %d", __func__,
+    LOG(INFO, "%s: Starting conntrack events thread. kind=%s is_src=%d",
+        __func__, save_input_kind_to_string(targs->targets->kind),
         targs->is_src);
 
     nl = mnl_socket_open(NETLINK_NETFILTER);
-    if (nl == NULL) {
-        LOG(ERROR, "%s: mnl_socket_open failed. %s", __func__,
-            strerror(errno));
-        return NULL;
-    }
-
-    if (mnl_socket_bind(nl, NF_NETLINK_CONNTRACK_NEW |
-                        NF_NETLINK_CONNTRACK_UPDATE |
-                        NF_NETLINK_CONNTRACK_DESTROY,
-                        MNL_SOCKET_AUTOPID) < 0) {
-        LOG(ERROR, "%s: mnl_socket_bind failed. %s", __func__,
-            strerror(errno));
-        mnl_socket_close(nl);
-        return NULL;
-    }
-
+     if (nl == NULL) {
+         LOG(ERROR, "%s: mnl_socket_open failed. %s", __func__,
+             strerror(errno));
+         return NULL;
+     }
+ 
+     if (mnl_socket_bind(nl, NF_NETLINK_CONNTRACK_NEW |
+                         NF_NETLINK_CONNTRACK_UPDATE |
+                         NF_NETLINK_CONNTRACK_DESTROY,
+                         MNL_SOCKET_AUTOPID) < 0) {
+         LOG(ERROR, "%s: mnl_socket_bind failed. %s", __func__,
+             strerror(errno));
+         mnl_socket_close(nl);
+         return NULL;
+     }
+ 
     listen_for_conntrack_events(nl, targs->targets,
                                 targs->is_src, targs->stop_flag);
     mnl_socket_close(nl);
 
-    LOG(INFO, "%s: Finished conntrack events. is_src = %d", __func__,
+    LOG(INFO, "%s: Finished conntrack events thread. kind=%s is_src=%d",
+        __func__, save_input_kind_to_string(targs->targets->kind),
         targs->is_src);
 
     return NULL;
 }
-
+ 
+ /**
+  * Gets all the entries present in the kernel CT table for the given
+  * SAVE migration targets.
+  *
+  * Args:
+  *   @targets SAVE targets bundle (mode-aware) used to filter the required
+  *            CT entries.
+  */
+ static void
+ dump_conntrack(struct save_targets *targets)
+ {
+     struct nfct_handle *handle;
+ 
+     // Set the subscriptions for this handle to 0 since we are going to
+     // explicitly request dump on this socket.
+     handle = nfct_open(CONNTRACK, 0);
+     if (handle == NULL) {
+         LOG(ERROR, "%s: nfct_open failed. %s", __func__, strerror(errno));
+         return;
+     }
+     get_conntrack_dump(handle, targets);
+     nfct_close(handle);
+ }
+ 
+ /**
+  * Spawn a single ct_events thread with the given is_src flag and
+  * pthread name. On success the thread owns the freshly allocated
+  * struct ct_events_targs and the caller receives it via @out_targs
+  * for later pthread_join + g_free. On failure @*out_targs is left
+  * untouched and the partial allocation is released here.
+  *
+  * Args:
+  *   @targets     SAVE targets bundle threaded down to the events
+  *                callback (read-only over the thread's lifetime).
+  *   @stop_flag   shared stop flag the thread polls for graceful exit.
+  *   @is_src      true for src-filtered BPF (IP mode src thread);
+  *                false for dst-filtered (IP mode dst thread) or for
+  *                the unfiltered zone-mode thread.
+  *   @thread_name pthread_setname_np tag; logged on rename failure.
+  *   @out_targs   output: owning pointer to the thread args bundle.
+  *
+  * Returns:
+  *   0 on success, -1 on pthread_create failure.
+  */
+ static int
+ create_events_thread(struct save_targets *targets, bool *stop_flag,
+                      bool is_src, const char *thread_name,
+                      struct ct_events_targs **out_targs)
+ {
+     struct ct_events_targs *targs;
+     int ret;
+ 
+     targs = g_malloc0(sizeof(*targs));
+     targs->targets   = targets;
+     targs->stop_flag = stop_flag;
+     targs->is_src    = is_src;
+ 
+     ret = pthread_create(&targs->tid, NULL, &pthread_wrapper_ct_events, targs);
+     if (ret != 0) {
+         LOG(ERROR, "%s: events thread '%s' creation failed: %s",
+             __func__, thread_name, strerror(ret));
+         g_free(targs);
+         return -1;
+     }
+     ret = pthread_setname_np(targs->tid, thread_name);
+     if (ret != 0) {
+         LOG(WARNING, "%s: failed to set thread name '%s': %s",
+             __func__, thread_name, strerror(ret));
+     }
+ 
+     *out_targs = targs;
+     return 0;
+ }
+ 
+ /**
+  * Spawn the conntrack delete thread.
+  *
+  * Mode-aware via ct_del_args.kind and the migrated-set pointers the
+  * caller has already populated on ct_del_args before this call. The
+  * thread is started in BOTH save sub-modes; its lifetime is what
+  * keeps the DBus main loop responsive to on_clear until the Clear
+  * IPC arrives and complete_on_clear drives g_main_loop_quit. Removing
+  * it for a mode would leave pthread_join in dmain waiting forever.
+  *
+  * Returns:
+  *   0 on success, -1 on pthread_create failure (in which case the
+  *   thread does not exist and ct_del_args.tid is left untouched).
+  */
+ static int
+ create_delete_thread(void)
+ {
+     int ret;
+ 
+     ret = pthread_create(&ct_del_args.tid, NULL,
+                          &delete_ct_entries, (void *)&ct_del_args);
+     if (ret != 0) {
+         LOG(ERROR, "%s: CT delete thread creation failed: %s",
+             __func__, strerror(ret));
+         return -1;
+     }
+     ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
+     if (ret != 0) {
+         LOG(WARNING, "%s: failed to set thread name 'ct_delete': %s",
+             __func__, strerror(ret));
+     }
+     return 0;
+ }
+ 
+ /**
+  * Start threads required for save mode of operation.
+  *
+  * Following things are performed in the save mode:
+  * 1. Conntrack delete thread is started which waits till Clear IPC is
+  *    called. The thread is started in both IP and zone sub-modes; it
+  *    dispatches on ct_del_args.kind when it wakes up.
+  * 2. Conntrack events threads are started to filter events for the
+  *    migration targets. In IP mode this is two BPF-filtered threads
+  *    (one src, one dst). In zone mode BPF can't filter on CT zone, so a
+  *    single unfiltered thread is started and the callback does the zone
+  *    match in-process.
+  *    If any update is received for a non-existent entry, it is treated
+  *    as NEW since it contains the base five tuple information required to
+  *    identify flow. Similarly, if a destroy event is received for a
+  *    non-existent entry, it is ignored.
+  * 3. Finally, Conntrack dump is taken from the kernel to get all the live
+  *    flows in the system.
+  *
+  * The above workflow is used to maintain a local copy of the CT entries for
+  * the VM.
+  *
+  * Args:
+  *   @targets SAVE targets bundle (mode-aware) for which CT entries have
+  *            to be migrated.
+  *   @stop_flag flag used by thread to exit after dbus operations.
+  *
+  * Returns:
+  *   0 in case of success, -1 otherwise
+  */
+ static int
+ start_in_save_mode(struct save_targets *targets, bool *stop_flag)
+ {
+     struct ct_events_targs *src_targs  = NULL;
+     struct ct_events_targs *dst_targs  = NULL;
+     struct ct_events_targs *zone_targs = NULL;
+     uint32_t num_entries;
+ 
+     /* Common: arity + early exits. The "no entries" path is not an
+      * error in either mode (e.g. a VM with no IPv4 NICs in IP mode);
+      * QEMU expects the helper to live for the migration window, so we
+      * just skip starting the worker threads and let the DBus loop run. */
+     if (targets->kind == SAVE_INPUT_IPS) {
+         num_entries = g_hash_table_size(targets->ips_to_migrate);
+     } else {
+         num_entries = g_hash_table_size(targets->zones_to_migrate);
+     }
+     if (num_entries == 0) {
+         LOG(INFO, "%s: No entries to migrate (kind=%s); skipping save "
+             "mode threads", __func__,
+             save_input_kind_to_string(targets->kind));
+         return 0;
+     }
+     /* IP-only: BPF filter cap. Zone mode does in-callback matching so
+      * the per-IP limit does not apply. */
+     if (targets->kind == SAVE_INPUT_IPS &&
+         num_entries > MAX_IP_ADDRESSES_SUPPORTED) {
+         LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
+             "No Conntrack Migration will be performed.",
+             MAX_IP_ADDRESSES_SUPPORTED);
+         return 0;
+     }
+ 
+     /* Common: wire up the delete-thread state, then create the thread.
+      * The delete thread is started in BOTH modes; the body of
+      * _delete_ct_entries dispatches on kind when on_clear wakes it up.
+      * NOTE: ct_del_args is an extern global. */
+     ct_del_args.kind = targets->kind;
+     if (targets->kind == SAVE_INPUT_IPS) {
+         ct_del_args.ips_migrated = targets->ips_to_migrate;
+     } else {
+         ct_del_args.zones_migrated = targets->zones_to_migrate;
+     }
+     if (create_delete_thread() != 0) {
+         return -1;
+     }
+ 
+     /* Mode-specific: create the events thread(s). IP mode runs two
+      * BPF-filtered threads (src + dst). Zone mode runs one unfiltered
+      * thread; the callback handles zone matching in-process because
+      * BPF cannot filter on CT zone. */
+     if (targets->kind == SAVE_INPUT_IPS) {
+         if (create_events_thread(targets, stop_flag, true,
+                                  "ct_events_src", &src_targs) != 0) {
+             goto cleanup_delete_thread;
+         }
+         if (create_events_thread(targets, stop_flag, false,
+                                  "ct_events_dst", &dst_targs) != 0) {
+             goto cleanup_delete_thread;
+         }
+     } else {
+         if (create_events_thread(targets, stop_flag, false,
+                                  "ct_events_zone", &zone_targs) != 0) {
+             goto cleanup_delete_thread;
+         }
+     }
+ 
+     /* Common: dump live entries, then join events thread(s) + delete
+      * thread in that order so on_clear can drive the shutdown. */
+     dump_conntrack(targets);
+ 
+     if (targets->kind == SAVE_INPUT_IPS) {
+         pthread_join(src_targs->tid, NULL);
+         pthread_join(dst_targs->tid, NULL);
+         g_free(src_targs);
+         g_free(dst_targs);
+     } else {
+         pthread_join(zone_targs->tid, NULL);
+         g_free(zone_targs);
+     }
+     pthread_join(ct_del_args.tid, NULL);
+     return 0;
+ 
+ cleanup_delete_thread:
+     /* Events thread creation failed after the delete thread was
+      * already started. Wake the delete thread with a sentinel clear
+      * so it doesn't block on clear_called_cond forever, join it, then
+      * free any partial events-thread allocations (NULL-safe). */
+     pthread_mutex_lock(&ct_del_args.mutex);
+     ct_del_args.clear_called = true;
+     pthread_cond_signal(&ct_del_args.clear_called_cond);
+     pthread_mutex_unlock(&ct_del_args.mutex);
+     pthread_join(ct_del_args.tid, NULL);
+     g_free(src_targs);
+     g_free(dst_targs);
+     g_free(zone_targs);
+     return -1;
+ }
+ 
+ /**
+  * Creates the ips_to_migrate hashtable from the legacy SAVE-mode CLI.
+  *
+  * Args:
+  *   @argv    array of CLI args.
+  *   @num_ips declared IP count from cli_mode_config.num_entries
+  *            (already validated by check_ip_save_args pre-fork). May
+  *            legitimately be 0 ("VM has no IPv4 NICs"; see the early
+  *            exit in start_in_save_mode).
+  *
+  * Returns:
+  *   Resulting hashtable containing IP address(uint32_t) as key.
+  */
+ static GHashTable *
+ create_ips_ht_from_args(const char *const argv[], int num_ips)
+ {
+     GHashTable *ht;
+     const char **ips = (const char **)(argv + IP_ADDR_LIST_ARG_INDEX);
+ 
+     ht = create_hashtable_from_ip_list(ips, num_ips);
+     if (ht == NULL) {
+         LOG(ERROR, "%s: Hashtable creation failed.", __func__);
+         return NULL;
+     }
+ 
+     return ht;
+ }
+ 
+ /**
+  * Creates the zones_to_migrate hashtable from the SAVE port-zone CLI
+  * arguments.
+  *
+  * Walks argv at the SAVE_PORT_ZONE_STRIDE-strided offsets, extracts the
+  * old_ct_zone column (the port_uuid column has already been validated
+  * pre-fork by check_zone_save_args and is otherwise discarded - the
+  * delete path filters strictly on CT zone), and hands the array to
+  * create_hashtable_from_zone_list().
+  *
+  * Args:
+  *   @argv      array of CLI args.
+  *   @n_entries declared entry count from cli_mode_config.num_entries
+  *              (already validated by check_zone_save_args pre-fork).
+  *
+  * Returns:
+  *   zones_to_migrate hashtable on success, NULL on failure.
+  */
+ static GHashTable *
+ create_zones_ht_from_args(const char *const argv[], int n_entries)
+ {
+     int i;
+     const char **zones;
+     GHashTable *ht;
+     const int old_zone_offset = 1;
+    
+     if (n_entries <= 0) {
+         LOG(ERROR, "%s: non-positive n_entries (%d)", __func__, n_entries);
+         return NULL;
+     }
+ 
+     if (argv == NULL) {
+         LOG(ERROR, "%s: argv is NULL", __func__);
+         return NULL;
+     }
+ 
+ 
+     zones = g_malloc0(sizeof(*zones) * n_entries);
+     for (i = 0; i < n_entries; i++) {
+         int port_uuid_index =
+             ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
+         int zone_index = port_uuid_index + old_zone_offset;
+         zones[i] = argv[zone_index];
+     }
+ 
+     ht = create_hashtable_from_zone_list(zones, n_entries);
+     g_free(zones);
+ 
+     if (ht == NULL) {
+         LOG(ERROR, "%s: Hashtable creation failed.", __func__);
+         return NULL;
+     }
+     return ht;
+ }
+ 
 /**
- * Gets all the entries present in the kernel CT table for the given
- * SAVE migration targets.
- *
- * Args:
- *   @targets SAVE targets bundle (mode-aware) used to filter the required
- *            CT entries.
- */
-static void
-dump_conntrack(struct save_targets *targets)
-{
-    struct nfct_handle *handle;
+ * Decides which SAVE-mode CLI layout we are looking at by comparing the
+  * number of trailing argv slots against the declared entry count N:
+  *
+  *   ratio = (argc - ENTRIES_LIST_START_ARG_INDEX) / N
+  *     ratio == 1 -> SAVE_INPUT_IPS         (one IP per entry)
+  *     ratio == 2 -> SAVE_INPUT_PORT_ZONES  (port_uuid + old_zone per entry)
+  *
+  * The "no list / N == 0" cases default to SAVE_INPUT_IPS so the existing
+  * "VM with no IPv4 NICs" passthrough in start_in_save_mode() stays intact.
+  *
+  * Called once pre-fork from check_save_mode_args(); the detected kind
+  * and declared N are recorded on cli_mode_config and read by dmain()
+  * after the double fork rather than re-detected.
+  *
+  * Args:
+  *   @argc           num of CLI arguments.
+  *   @argv           array of CLI arguments.
+  *   @out_n_entries  output for the declared entry count. Set to 0 on the
+  *                   "no list" shortcut so the caller can record it on
+  *                   cli_mode_config without an extra parse of argv[3].
+  *
+  * Returns:
+  *   The detected sub-mode. Aborts the process via errx() on a shape
+  *   mismatch (declared N is non-zero but trailing args fit neither layout).
+  */
+ static enum save_input_kind
+ detect_save_input_kind(int argc, const char *const argv[], int *out_n_entries)
+ {
+     int n;
+     int remaining;
+ 
+     if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
+         *out_n_entries = 0;
+         return SAVE_INPUT_IPS;
+     }
+ 
+     ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                    "num_entries",
+                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
+     *out_n_entries = n;
+ 
+    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
 
-    // Set the subscriptions for this handle to 0 since we are going to
-    // explicitly request dump on this socket.
-    handle = nfct_open(CONNTRACK, 0);
-    if (handle == NULL) {
-        LOG(ERROR, "%s: nfct_open failed. %s", __func__, strerror(errno));
-        return;
+    if (remaining == n * IP_STRIDE) {
+        return SAVE_INPUT_IPS;
     }
-    get_conntrack_dump(handle, targets);
-    nfct_close(handle);
+    if (remaining == n * SAVE_PORT_ZONE_STRIDE) {
+        return SAVE_INPUT_PORT_ZONES;
+    }
+
+    errx(EXIT_FAILURE,
+         "SAVE mode: argv shape mismatch. N=%d, expected %d args (IP form) "
+         "or %d args (port-zone form), got %d.",
+         n, n * IP_STRIDE, n * SAVE_PORT_ZONE_STRIDE, remaining);
 }
-
-/**
- * Spawn a single ct_events thread with the given is_src flag and
- * pthread name. On success the thread owns the freshly allocated
- * struct ct_events_targs and the caller receives it via @out_targs
- * for later pthread_join + g_free. On failure @*out_targs is left
- * untouched and the partial allocation is released here.
- *
- * Args:
- *   @targets     SAVE targets bundle threaded down to the events
- *                callback (read-only over the thread's lifetime).
- *   @stop_flag   shared stop flag the thread polls for graceful exit.
- *   @is_src      true for src-filtered BPF (IP mode src thread);
- *                false for dst-filtered (IP mode dst thread) or for
- *                the unfiltered zone-mode thread.
- *   @thread_name pthread_setname_np tag; logged on rename failure.
- *   @out_targs   output: owning pointer to the thread args bundle.
- *
- * Returns:
- *   0 on success, -1 on pthread_create failure.
- */
-static int
-create_events_thread(struct save_targets *targets, bool *stop_flag,
-                     bool is_src, const char *thread_name,
-                     struct ct_events_targs **out_targs)
-{
-    struct ct_events_targs *targs;
-    int ret;
-
-    targs = g_malloc0(sizeof(*targs));
-    targs->targets   = targets;
-    targs->stop_flag = stop_flag;
-    targs->is_src    = is_src;
-
-    ret = pthread_create(&targs->tid, NULL, &pthread_wrapper_ct_events, targs);
-    if (ret != 0) {
-        LOG(ERROR, "%s: events thread '%s' creation failed: %s",
-            __func__, thread_name, strerror(ret));
-        g_free(targs);
-        return -1;
-    }
-    ret = pthread_setname_np(targs->tid, thread_name);
-    if (ret != 0) {
-        LOG(WARNING, "%s: failed to set thread name '%s': %s",
-            __func__, thread_name, strerror(ret));
-    }
-
-    *out_targs = targs;
-    return 0;
-}
-
-/**
- * Spawn the conntrack delete thread.
- *
- * Mode-aware via ct_del_args.kind and the migrated-set pointers the
- * caller has already populated on ct_del_args before this call. The
- * thread is started in BOTH save sub-modes; its lifetime is what
- * keeps the DBus main loop responsive to on_clear until the Clear
- * IPC arrives and complete_on_clear drives g_main_loop_quit. Removing
- * it for a mode would leave pthread_join in dmain waiting forever.
- *
- * Returns:
- *   0 on success, -1 on pthread_create failure (in which case the
- *   thread does not exist and ct_del_args.tid is left untouched).
- */
-static int
-create_delete_thread(void)
-{
-    int ret;
-
-    ret = pthread_create(&ct_del_args.tid, NULL,
-                         &delete_ct_entries, (void *)&ct_del_args);
-    if (ret != 0) {
-        LOG(ERROR, "%s: CT delete thread creation failed: %s",
-            __func__, strerror(ret));
-        return -1;
-    }
-    ret = pthread_setname_np(ct_del_args.tid, "ct_delete");
-    if (ret != 0) {
-        LOG(WARNING, "%s: failed to set thread name 'ct_delete': %s",
-            __func__, strerror(ret));
-    }
-    return 0;
-}
-
-/**
- * Start threads required for save mode of operation.
- *
- * Following things are performed in the save mode:
- * 1. Conntrack delete thread is started which waits till Clear IPC is
- *    called. The thread is started in both IP and zone sub-modes; it
- *    dispatches on ct_del_args.kind when it wakes up.
- * 2. Conntrack events threads are started to filter events for the
- *    migration targets. In IP mode this is two BPF-filtered threads
- *    (one src, one dst). In zone mode BPF can't filter on CT zone, so a
- *    single unfiltered thread is started and the callback does the zone
- *    match in-process.
- *    If any update is received for a non-existent entry, it is treated
- *    as NEW since it contains the base five tuple information required to
- *    identify flow. Similarly, if a destroy event is received for a
- *    non-existent entry, it is ignored.
- * 3. Finally, Conntrack dump is taken from the kernel to get all the live
- *    flows in the system.
- *
- * The above workflow is used to maintain a local copy of the CT entries for
- * the VM.
- *
- * Args:
- *   @targets SAVE targets bundle (mode-aware) for which CT entries have
- *            to be migrated.
- *   @stop_flag flag used by thread to exit after dbus operations.
- *
- * Returns:
- *   0 in case of success, -1 otherwise
- */
-static int
-start_in_save_mode(struct save_targets *targets, bool *stop_flag)
-{
-    struct ct_events_targs *src_targs  = NULL;
-    struct ct_events_targs *dst_targs  = NULL;
-    struct ct_events_targs *zone_targs = NULL;
-    uint32_t num_entries;
-
-    /* Common: arity + early exits. The "no entries" path is not an
-     * error in either mode (e.g. a VM with no IPv4 NICs in IP mode);
-     * QEMU expects the helper to live for the migration window, so we
-     * just skip starting the worker threads and let the DBus loop run. */
-    if (targets->kind == SAVE_INPUT_IPS) {
-        num_entries = g_hash_table_size(targets->ips_to_migrate);
-    } else {
-        num_entries = g_hash_table_size(targets->zones_to_migrate);
-    }
-    if (num_entries == 0) {
-        LOG(INFO, "%s: No entries to migrate (kind=%s); skipping save "
-            "mode threads", __func__,
-            save_input_kind_to_string(targets->kind));
-        return 0;
-    }
-    /* IP-only: BPF filter cap. Zone mode does in-callback matching so
-     * the per-IP limit does not apply. */
-    if (targets->kind == SAVE_INPUT_IPS &&
-        num_entries > MAX_IP_ADDRESSES_SUPPORTED) {
-        LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
-            "No Conntrack Migration will be performed.",
-            MAX_IP_ADDRESSES_SUPPORTED);
-        return 0;
-    }
-
-    /* Common: wire up the delete-thread state, then create the thread.
-     * The delete thread is started in BOTH modes; the body of
-     * _delete_ct_entries dispatches on kind when on_clear wakes it up.
-     * NOTE: ct_del_args is an extern global. */
-    ct_del_args.kind = targets->kind;
-    if (targets->kind == SAVE_INPUT_IPS) {
-        ct_del_args.ips_migrated = targets->ips_to_migrate;
-    } else {
-        ct_del_args.zones_migrated = targets->zones_to_migrate;
-    }
-    if (create_delete_thread() != 0) {
-        return -1;
-    }
-
-    /* Mode-specific: create the events thread(s). IP mode runs two
-     * BPF-filtered threads (src + dst). Zone mode runs one unfiltered
-     * thread; the callback handles zone matching in-process because
-     * BPF cannot filter on CT zone. */
-    if (targets->kind == SAVE_INPUT_IPS) {
-        if (create_events_thread(targets, stop_flag, true,
-                                 "ct_events_src", &src_targs) != 0) {
-            goto cleanup_delete_thread;
+ 
+ /**
+  * Decides which LOAD-mode CLI layout we are looking at.
+  *
+  * Legacy LOAD is strictly: `conntrack_migrator 1 <helper_id>` (argc == 3).
+  * New LOAD is:             `conntrack_migrator 1 <helper_id> <N>
+  *                              <port_uuid> <old_ct_zone> <new_ct_zone> ...`
+  *                          (argc == 4 + 3*N).
+  *
+  * Anything else is a hard error - we deliberately do NOT silently fall back
+  * to legacy if the trailing args do not match the new shape.
+  *
+  * Called once pre-fork from check_load_mode_args(); the detected kind
+  * and declared N are recorded on cli_mode_config and read by dmain()
+  * after the double fork rather than re-detected (mirroring
+  * detect_save_input_kind above).
+  *
+  * Args:
+  *   @argc           num of CLI arguments.
+  *   @argv           array of CLI arguments.
+  *   @out_n_entries  output for the declared entry count. Set to 0 on the
+  *                   legacy shortcut so the caller can record it on
+  *                   cli_mode_config without an extra parse of argv[3].
+  *
+  * Returns:
+  *   The detected sub-mode. Aborts the process via errx() on any mismatch.
+  */
+ static enum load_input_kind
+ detect_load_input_kind(int argc, const char *const argv[], int *out_n_entries)
+ {
+     int n;
+     int remaining;
+ 
+     if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
+         *out_n_entries = 0;
+         return LOAD_INPUT_LEGACY;
+     }
+ 
+     if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
+         errx(EXIT_FAILURE,
+              "LOAD mode: trailing args present but no port-zone list. "
+              "Expected `conntrack_migrator 1 <helper_id>` or "
+              "`conntrack_migrator 1 <helper_id> <N> "
+              "<port_uuid> <old_zone> <new_zone> ...`.");
+     }
+ 
+     ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                    "LOAD num_entries",
+                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
+     *out_n_entries = n;
+ 
+     remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
+ 
+     if (remaining == n * LOAD_PORT_ZONE_STRIDE) {
+         return LOAD_INPUT_PORT_ZONES;
+     }
+ 
+     errx(EXIT_FAILURE,
+          "LOAD mode: argv shape mismatch. N=%d, expected %d args "
+          "(port-zone form), got %d.",
+          n, n * LOAD_PORT_ZONE_STRIDE, remaining);
+ }
+ 
+ /**
+  * Checks if the mode passed is either LOAD or SAVE.
+  *
+  * Called once pre-fork from check_args(); an out-of-set mode aborts
+  * the process via errx() before fork happens, so dmain() is guaranteed
+  * to receive a valid cli_mode_config.mode value.
+  *
+  * Args:
+  *   @mode operating mode
+  */
+ static void
+ check_mode(int mode)
+ {
+     if ((mode != LOAD_MODE) && (mode != SAVE_MODE)) {
+         errx(EXIT_FAILURE, "Incorrect mode passed. Should be 1 (LOAD) or "
+                 "2 (SAVE)\n");
+     }
+ }
+ 
+ /**
+  * Entry point for the daemon.
+  *
+  * Args:
+  *   @argc num of arguments to the application.
+  *   @argv string argument list.
+  *   @cli  parsed CLI bundle populated by check_args() before the
+  *         daemon was forked. Mode, sub-kind, and num_entries are read
+  *         directly from here instead of re-walking argv. fork() copies
+  *         the entire address space (including the parent's stack frame),
+  *         so the pointer is valid in the grandchild.
+  *
+  * Returns:
+  *   0 if the daemon exits without any error. otherwise the specific error
+  *   code is returned.
+  */
+ static int
+ dmain(int argc, const char *const argv[], const struct cli_mode_config *cli)
+ {
+     const char *helper_id;
+     int ret;
+     int rc = 0;
+     bool stop_flag = false;
+     bool log_open = false;
+     bool dbus_started = false;
+     bool loop_mu_inited = false;
+     struct dbus_targs dbus_server_args = {0};
+     struct save_targets *save_targets = NULL;
+ 
+     (void) argc;
+ 
+     if (argv == NULL || cli == NULL) {
+         return EINVAL;
+     }
+ 
+     helper_id = argv[HELPER_ID_ARG_INDEX];
+ 
+     // Initialise logging at default INFO level.
+     ret = init_log(INFO, helper_id);
+     if (ret != 0) {
+         return EAGAIN;   // nothing else allocated yet
+     }
+     log_open = true;
+ 
+     // Init configs.
+     init_lmct_config(lmct_config_path);
+ 
+     // set the logging level read from config.
+     set_log_level(lmct_conf.log_lvl);
+ 
+     LOG(INFO, "%s: Starting in mode %s", __func__,
+         mode_to_string[cli->mode]);
+     LOG(INFO, "%s: dbus address %s", __func__,
+         getenv("DBUS_SYSTEM_BUS_ADDRESS"));
+     LOG(INFO, "%s: helper id: %s", __func__, helper_id);
+     LOG(INFO, "%s: Maximum CT entries migratable: %d", __func__,
+         lmct_conf.max_entries_to_migrate);
+ 
+     // Initialise globals.
+     conn_store = conntrack_store_new();
+     if (conn_store == NULL) {
+         LOG(ERROR, "%s: connection_store is NULL", __func__);
+         rc = EAGAIN;
+         goto cleanup;
+     }
+ 
+     // Start the dbus server
+     dbus_server_args.helper_id    = helper_id;
+     dbus_server_args.stop_flag    = &stop_flag;
+     dbus_server_args.mode         = cli->mode;
+     dbus_server_args.load_targets = NULL;
+     dbus_server_args.loop         = NULL;
+     dbus_server_args.should_quit  = false;
+     ret = pthread_mutex_init(&dbus_server_args.loop_mu, NULL);
+     if (ret != 0) {
+         LOG(ERROR, "%s: failed to init loop_mu: %s", __func__, strerror(ret));
+         rc = EAGAIN;
+         goto cleanup;
+     }
+     loop_mu_inited = true;
+ 
+    /* In LOAD mode wire the dbus thread to the pre-built (old_zone ->
+     * new_zone) remap so it's ready by the time the destination's Load
+     * IPC arrives. The remap was built and validated pre-fork in
+     * check_zone_load_args() and rides through fork() in cli->zone_remap
+     * via COW of the parent's address space. SAVE mode and LOAD-legacy
+     * mode leave zone_remap NULL. */
+    if (cli->mode == LOAD_MODE) {
+        if (cli->load_kind == LOAD_INPUT_LEGACY) {
+            dbus_server_args.load_targets = load_targets_new_ips();
+            LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
+        } else {
+            dbus_server_args.load_targets =
+                load_targets_new_from_remap(cli->zone_remap);
+            if (dbus_server_args.load_targets == NULL) {
+                LOG(ERROR, "%s: failed to create load_targets", __func__);
+                rc = EINVAL;
+                goto cleanup;
+            }
+            LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
+                __func__, cli->num_entries);
         }
-        if (create_events_thread(targets, stop_flag, false,
-                                 "ct_events_dst", &dst_targs) != 0) {
-            goto cleanup_delete_thread;
-        }
-    } else {
-        if (create_events_thread(targets, stop_flag, false,
-                                 "ct_events_zone", &zone_targs) != 0) {
-            goto cleanup_delete_thread;
-        }
     }
-
-    /* Common: dump live entries, then join events thread(s) + delete
-     * thread in that order so on_clear can drive the shutdown. */
-    dump_conntrack(targets);
-
-    if (targets->kind == SAVE_INPUT_IPS) {
-        pthread_join(src_targs->tid, NULL);
-        pthread_join(dst_targs->tid, NULL);
-        g_free(src_targs);
-        g_free(dst_targs);
-    } else {
-        pthread_join(zone_targs->tid, NULL);
-        g_free(zone_targs);
-    }
-    pthread_join(ct_del_args.tid, NULL);
-    return 0;
-
-cleanup_delete_thread:
-    /* Events thread creation failed after the delete thread was
-     * already started. Wake the delete thread with a sentinel clear
-     * so it doesn't block on clear_called_cond forever, join it, then
-     * free any partial events-thread allocations (NULL-safe). */
-    pthread_mutex_lock(&ct_del_args.mutex);
-    ct_del_args.clear_called = true;
-    pthread_cond_signal(&ct_del_args.clear_called_cond);
-    pthread_mutex_unlock(&ct_del_args.mutex);
-    pthread_join(ct_del_args.tid, NULL);
-    g_free(src_targs);
-    g_free(dst_targs);
-    g_free(zone_targs);
-    return -1;
-}
-
+ 
+     ret = pthread_create(&dbus_server_args.tid,
+                          NULL, dbus_server_init,
+                          &dbus_server_args);
+     if (ret != 0) {
+         LOG(ERROR, "%s: dbus_server thread creation failed. %s", __func__,
+             strerror(ret));
+         rc = EAGAIN;
+         goto cleanup;
+     }
+     dbus_started = true;
+     ret = pthread_setname_np(dbus_server_args.tid, "dbus_server");
+     if (ret != 0) {
+         LOG(WARNING, "%s: Failed to set thread name \"dbus_server\". %s",
+             __func__, strerror(ret));
+     }
+ 
+     // Start save mode threads.
+     if (cli->mode == SAVE_MODE) {
+         if (cli->save_kind == SAVE_INPUT_IPS) {
+             GHashTable *ips_to_migrate;
+             ips_to_migrate = create_ips_ht_from_args(argv, cli->num_entries);
+             if (ips_to_migrate == NULL) {
+                 rc = EINVAL;
+                 goto cleanup;
+             }
+             save_targets = save_targets_new_from_ips(ips_to_migrate);
+         } else {
+             GHashTable *zones_ht =
+                 create_zones_ht_from_args(argv, cli->num_entries);
+             if (zones_ht == NULL) {
+                 rc = EINVAL;
+                 goto cleanup;
+             }
+             save_targets = save_targets_new_from_zones(zones_ht);
+         }
+ 
+         ret = start_in_save_mode(save_targets, &stop_flag);
+         if (ret != 0) {
+             rc = EAGAIN;
+             /* start_in_save_mode may have left events threads running
+              * that still reference save_targets (a pre-existing issue
+              * tracked separately). Don't destroy save_targets in that
+              * case -- a small intentional leak on the abnormal-exit
+              * path is preferable to a use-after-free. */
+             save_targets = NULL;
+         }
+     }
+ 
+ cleanup:
+     /* Tell any still-running events threads to exit. start_in_save_mode
+      * normally joins them itself, but we set this defensively to cover
+      * partial-failure paths that leave the events threads alive. */
+     stop_flag = true;
+ 
+     /* Wake the dbus thread on every error path so pthread_join below
+      * doesn't hang waiting for an RPC that will never arrive. On the
+      * normal success path the loop has already quit itself (via
+      * on_save -> ... -> on_clear -> g_main_loop_quit for SAVE, and
+      * on_load -> g_main_loop_quit for LOAD), so request_quit is a no-op
+      * there. */
+     if (dbus_started) {
+         if (rc != 0) {
+             dbus_server_request_quit(&dbus_server_args);
+         }
+         pthread_join(dbus_server_args.tid, NULL);
+     }
+     if (save_targets != NULL) {
+         save_targets_destroy(save_targets);
+     }
+     if (dbus_server_args.load_targets != NULL) {
+         load_targets_destroy(dbus_server_args.load_targets);
+     }
+     if (loop_mu_inited) {
+         pthread_mutex_destroy(&dbus_server_args.loop_mu);
+     }
+     if (conn_store != NULL) {
+         conntrack_store_destroy(conn_store);
+         conn_store = NULL;
+     }
+     if (log_open) {
+         close_log();
+     }
+ 
+     return rc;
+ }
+ 
+ static void
+ err_usage(void)
+ {
+     errx(EXIT_FAILURE,
+         "Usage:\n"
+         "  Legacy IP-based:\n"
+         "    SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 "
+             "<helper_id> <num_ips> <ip1> <ip2> ...\n"
+         "    LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 "
+             "<helper_id>\n"
+         "  Port/CT-zone-based:\n"
+         "    SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 "
+             "<helper_id> <N> <port_uuid_1> <old_ct_zone_1> ... "
+             "<port_uuid_N> <old_ct_zone_N>\n"
+         "    LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 "
+             "<helper_id> <N> <port_uuid_1> <old_ct_zone_1> <new_ct_zone_1> "
+             "... <port_uuid_N> <old_ct_zone_N> <new_ct_zone_N>\n"
+         "NOTE: DBUS_SYSTEM_BUS_ADDRESS env variable must be set.\n");
+ }
+ 
+ /**
+  * Checks if the DBUS_SYSTEM_BUS_ADDRESS env variable is set.
+  */
+ static void
+ check_dbus_address_env(void)
+ {
+     const char *dbus_address = getenv("DBUS_SYSTEM_BUS_ADDRESS");
+     if (dbus_address == NULL || strcmp(dbus_address, "") == 0) {
+         errx(EXIT_FAILURE, "DBUS_SYSTEM_BUS_ADDRESS environment variable not "
+                 "set\n");
+     }
+ }
+ 
+ /**
+  * Performs checks on args when started in save mode (legacy IP form).
+  *
+  * Checks performed:
+  * 1. Num of ip address param is present and is non-negative.
+  * 2. The ip address list size matches the num of ip addresses provided.
+  *
+  * NOTE: this is the legacy SAVE validator, kept verbatim from the original
+  * implementation. The 127-IP cap referenced in the original docstring is
+  * enforced later in start_in_save_mode().
+  *
+  * Args:
+  *   @argc num of arguments.
+  *   @argv array of CLI arguments.
+  */
+ static void
+ check_ip_save_args(int argc, const char *const argv[])
+ {
+     int num_ip_addr;
+ 
+     if (argc < 4) {
+         errx(EXIT_FAILURE, "Number of IP addresses not present in args");
+     }
+ 
+     /* min_value = 0 (not 1) because num_ip_addr == 0 is the legitimate
+      * "VM has no IPv4 NICs" case. The helper rejects negatives and
+      * non-numeric input; we still need the count-vs-argc check below
+      * to catch "I declared 5 IPs but only passed 2". */
+     ensure_cli_arg_is_int_at_least(argv[NUM_IP_ADDR_ARG_INDEX], &num_ip_addr,
+                                    "num_ips", MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS);
+     if (num_ip_addr > (argc - IP_ADDR_LIST_ARG_INDEX)) {
+         errx(EXIT_FAILURE,
+              "Declared num_ips (%d) exceeds the number of IP addresses "
+              "supplied in argv (%d)",
+              num_ip_addr, argc - IP_ADDR_LIST_ARG_INDEX);
+     }
+ }
+ 
+ /**
+  * Per-entry content checks for the new SAVE port-zone layout.
+  *
+  * Arity (argc vs declared N) is guaranteed by detect_save_input_kind()
+  * before we get here, so we only validate the *content* of each entry:
+  *  - port_uuid is a port-prefixed canonical UUID of the form
+  *    "port_<8-4-4-4-12>" (total length 41),
+  *  - old_ct_zone parses cleanly as uint16.
+  *
+  * Aborts the process via errx() on the first malformed entry.
+  *
+  * Args:
+  *   @argc num of arguments (used only for an arity sanity check).
+  *   @argv array of CLI arguments.
+  */
+ static void
+ check_zone_save_args(int argc, const char *const argv[])
+ {
+     int n;
+     int i;
+     const int old_zone_offset = 1;
+ 
+     (void) argc;
+ 
+     ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                    "num_entries",
+                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
+ 
+     for (i = 0; i < n; i++) {
+         int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
+         const char *port_uuid = argv[base];
+         const char *zone_str  = argv[base + old_zone_offset];
+         uint16_t zone_val;
+ 
+         if (!is_valid_uuid_string(port_uuid)) {
+             errx(EXIT_FAILURE,
+                  "Invalid UUID at port-zone entry %d: '%s'",
+                  i, port_uuid);
+         }
+         if (!parse_ct_zone(zone_str, &zone_val)) {
+             errx(EXIT_FAILURE,
+                  "Invalid old_ct_zone at port-zone entry %d: '%s' "
+                  "(must be uint16)", i, zone_str);
+         }
+     }
+ }
+ 
 /**
- * Creates the ips_to_migrate hashtable from the legacy SAVE-mode CLI.
+ * Per-entry content checks for the new LOAD port-zone layout, folded
+ * with the (old_zone -> new_zone) remap build into a single argv pass.
+ *
+ * Arity is guaranteed by detect_load_input_kind(); we validate the content
+ * of each (port_uuid, old_ct_zone, new_ct_zone) triple and, on success,
+ * insert (old_zone -> new_zone) into a freshly allocated remap hashtable.
+ * Returning the remap directly (instead of validating now and reparsing
+ * post-fork via a separate builder) lets dmain() consume cli->zone_remap
+ * without re-walking argv. The port_uuid column is content-checked here
+ * but not stored: at LOAD time each CT entry only carries ATTR_ZONE, so
+ * the only usable pivot is old_zone -> new_zone.
+ *
+ * If two entries declare the same old_zone with different new_zones, the
+ * last write wins and a WARNING is logged. Bad input (malformed UUID or
+ * unparseable zone) aborts the process via errx(), matching the fail-fast
+ * contract of all other check_*_args helpers.
  *
  * Args:
- *   @argv    array of CLI args.
- *   @num_ips declared IP count from cli_mode_config.num_entries
- *            (already validated by check_ip_save_args pre-fork). May
- *            legitimately be 0 ("VM has no IPv4 NICs"; see the early
- *            exit in start_in_save_mode).
+ *   @argc num of arguments (used only for an arity sanity check).
+ *   @argv array of CLI arguments.
  *
  * Returns:
- *   Resulting hashtable containing IP address(uint32_t) as key.
+ *   Newly allocated (old_zone -> new_zone) hashtable. Ownership transfers
+ *   to the caller; consumed by load_targets_new_from_remap() in dmain().
  */
 static GHashTable *
-create_ips_ht_from_args(const char *const argv[], int num_ips)
-{
-    GHashTable *ht;
-    const char *const *ips = argv + IP_ADDR_LIST_ARG_INDEX;
-
-    ht = create_hashtable_from_ip_list(ips, num_ips);
-    if (ht == NULL) {
-        LOG(ERROR, "%s: Hashtable creation failed.", __func__);
-        return NULL;
-    }
-
-    return ht;
-}
-
-/**
- * Creates the zones_to_migrate hashtable from the SAVE port-zone CLI
- * arguments.
- *
- * Walks argv at the SAVE_PORT_ZONE_STRIDE-strided offsets, extracts the
- * old_ct_zone column (the port_uuid column has already been validated
- * pre-fork by check_zone_save_args and is otherwise discarded - the
- * delete path filters strictly on CT zone), and hands the array to
- * create_hashtable_from_zone_list().
- *
- * Args:
- *   @argv      array of CLI args.
- *   @n_entries declared entry count from cli_mode_config.num_entries
- *              (already validated by check_zone_save_args pre-fork).
- *
- * Returns:
- *   zones_to_migrate hashtable on success, NULL on failure.
- */
-static GHashTable *
-create_zones_ht_from_args(const char *const argv[], int n_entries)
-{
-    int i;
-    const char **zones;
-    GHashTable *ht;
-    const int old_zone_offset = 1;
-   
-    if (n_entries <= 0) {
-        LOG(ERROR, "%s: non-positive n_entries (%d)", __func__, n_entries);
-        return NULL;
-    }
-
-    if (argv == NULL) {
-        LOG(ERROR, "%s: argv is NULL", __func__);
-        return NULL;
-    }
-
-
-    zones = g_malloc0(sizeof(*zones) * n_entries);
-    for (i = 0; i < n_entries; i++) {
-        int port_uuid_index =
-            ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
-        int zone_index = port_uuid_index + old_zone_offset;
-        zones[i] = argv[zone_index];
-    }
-
-    ht = create_hashtable_from_zone_list(zones, n_entries);
-    g_free(zones);
-
-    if (ht == NULL) {
-        LOG(ERROR, "%s: Hashtable creation failed.", __func__);
-        return NULL;
-    }
-    return ht;
-}
-
-/**
- * Parses N port-zone-remap entries out of argv into an
- * old_zone -> new_zone hashtable for LOAD-mode use.
- *
- * Mirrors create_zones_ht_from_args() on the SAVE side. The port_uuid
- * column at offset 0 is intentionally ignored: at LOAD time each CT
- * entry only carries ATTR_ZONE, so the only usable pivot is
- * old_zone -> new_zone. UUID well-formedness has already been
- * validated by check_zone_load_args() pre-fork.
- *
- * If two entries declare the same old_zone with different new_zones,
- * the last write wins and a WARNING is logged.
- *
- * Args:
- *   @argv      full argv array.
- *   @n_entries declared entry count from cli_mode_config.num_entries
- *              (already validated by check_zone_load_args pre-fork;
- *              must be > 0 - caller branches on load_kind first).
- *
- * Returns:
- *   remap hashtable on success (caller owns it), NULL on parse
- *   failure (partially-built remap is torn down before returning).
- */
-static GHashTable *
-build_zone_remap_from_args(const char *const argv[], int n_entries)
+check_zone_load_args(int argc, const char *const argv[])
 {
     GHashTable *remap;
+    int n;
     int i;
     const int old_zone_offset = 1;
     const int new_zone_offset = 2;
 
-    if (n_entries <= 0) {
-        LOG(ERROR, "%s: non-positive n_entries (%d)", __func__, n_entries);
-        return NULL;
-    }
+    (void) argc;
 
-    if (argv == NULL) {
-        LOG(ERROR, "%s: argv is NULL there are no port-zone remap entries", __func__);
-        return NULL;
-    }
+    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
+                                   "num_entries",
+                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
 
     remap = g_hash_table_new(g_direct_hash, g_direct_equal);
 
-    for (i = 0; i < n_entries; i++) {
+    for (i = 0; i < n; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
+        const char *port_uuid    = argv[base];
         const char *old_zone_str = argv[base + old_zone_offset];
         const char *new_zone_str = argv[base + new_zone_offset];
         uint16_t old_zone, new_zone;
         gpointer existing_val;
 
-        if (!parse_ct_zone(old_zone_str, &old_zone) ||
-            !parse_ct_zone(new_zone_str, &new_zone)) {
-            LOG(ERROR, "%s: failed to parse zone at entry %d "
-                "(old='%s' new='%s')",
-                __func__, i, old_zone_str, new_zone_str);
+        if (!is_valid_uuid_string(port_uuid)) {
             g_hash_table_destroy(remap);
-            return NULL;
+            errx(EXIT_FAILURE,
+                 "Invalid UUID at port-zone entry %d: '%s'",
+                 i, port_uuid);
+        }
+        if (!parse_ct_zone(old_zone_str, &old_zone)) {
+            g_hash_table_destroy(remap);
+            errx(EXIT_FAILURE,
+                 "Invalid old_ct_zone at port-zone entry %d: '%s'",
+                 i, old_zone_str);
+        }
+        if (!parse_ct_zone(new_zone_str, &new_zone)) {
+            g_hash_table_destroy(remap);
+            errx(EXIT_FAILURE,
+                 "Invalid new_ct_zone at port-zone entry %d: '%s'",
+                 i, new_zone_str);
         }
 
         if (g_hash_table_lookup_extended(remap,
@@ -580,575 +1050,88 @@ build_zone_remap_from_args(const char *const argv[], int n_entries)
 
     return remap;
 }
-
-/**
- * Decides which SAVE-mode CLI layout we are looking at by comparing the
- * number of trailing argv slots against the declared entry count N:
- *
- *   ratio = (argc - ENTRIES_LIST_START_ARG_INDEX) / N
- *     ratio == 1 -> SAVE_INPUT_IPS         (one IP per entry)
- *     ratio == 2 -> SAVE_INPUT_PORT_ZONES  (port_uuid + old_zone per entry)
- *
- * The "no list / N == 0" cases default to SAVE_INPUT_IPS so the existing
- * "VM with no IPv4 NICs" passthrough in start_in_save_mode() stays intact.
- *
- * Called once pre-fork from check_save_mode_args(); the detected kind
- * and declared N are recorded on cli_mode_config and read by dmain()
- * after the double fork rather than re-detected.
- *
- * Args:
- *   @argc           num of CLI arguments.
- *   @argv           array of CLI arguments.
- *   @out_n_entries  output for the declared entry count. Set to 0 on the
- *                   "no list" shortcut so the caller can record it on
- *                   cli_mode_config without an extra parse of argv[3].
- *
- * Returns:
- *   The detected sub-mode. Aborts the process via errx() on a shape
- *   mismatch (declared N is non-zero but trailing args fit neither layout).
- */
-static enum save_input_kind
-detect_save_input_kind(int argc, const char *const argv[], int *out_n_entries)
-{
-    int n;
-    int remaining;
-
-    if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
-        *out_n_entries = 0;
-        return SAVE_INPUT_IPS;
-    }
-
-    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
-                                   "num_entries",
-                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
-    *out_n_entries = n;
-
-    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
-
-    if (remaining == n) {
-        return SAVE_INPUT_IPS;
-    }
-    if (remaining == n * SAVE_PORT_ZONE_STRIDE) {
-        return SAVE_INPUT_PORT_ZONES;
-    }
-
-    errx(EXIT_FAILURE,
-         "SAVE mode: argv shape mismatch. N=%d, expected %d args (IP form) "
-         "or %d args (port-zone form), got %d.",
-         n, n * 1, n * SAVE_PORT_ZONE_STRIDE, remaining);
-}
-
-/**
- * Decides which LOAD-mode CLI layout we are looking at.
- *
- * Legacy LOAD is strictly: `conntrack_migrator 1 <helper_id>` (argc == 3).
- * New LOAD is:             `conntrack_migrator 1 <helper_id> <N>
- *                              <port_uuid> <old_ct_zone> <new_ct_zone> ...`
- *                          (argc == 4 + 3*N).
- *
- * Anything else is a hard error - we deliberately do NOT silently fall back
- * to legacy if the trailing args do not match the new shape.
- *
- * Called once pre-fork from check_load_mode_args(); the detected kind
- * and declared N are recorded on cli_mode_config and read by dmain()
- * after the double fork rather than re-detected (mirroring
- * detect_save_input_kind above).
- *
- * Args:
- *   @argc           num of CLI arguments.
- *   @argv           array of CLI arguments.
- *   @out_n_entries  output for the declared entry count. Set to 0 on the
- *                   legacy shortcut so the caller can record it on
- *                   cli_mode_config without an extra parse of argv[3].
- *
- * Returns:
- *   The detected sub-mode. Aborts the process via errx() on any mismatch.
- */
-static enum load_input_kind
-detect_load_input_kind(int argc, const char *const argv[], int *out_n_entries)
-{
-    int n;
-    int remaining;
-
-    if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
-        *out_n_entries = 0;
-        return LOAD_INPUT_LEGACY;
-    }
-
-    if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
-        errx(EXIT_FAILURE,
-             "LOAD mode: trailing args present but no port-zone list. "
-             "Expected `conntrack_migrator 1 <helper_id>` or "
-             "`conntrack_migrator 1 <helper_id> <N> "
-             "<port_uuid> <old_zone> <new_zone> ...`.");
-    }
-
-    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
-                                   "LOAD num_entries",
-                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
-    *out_n_entries = n;
-
-    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
-
-    if (remaining == n * LOAD_PORT_ZONE_STRIDE) {
-        return LOAD_INPUT_PORT_ZONES;
-    }
-
-    errx(EXIT_FAILURE,
-         "LOAD mode: argv shape mismatch. N=%d, expected %d args "
-         "(port-zone form), got %d.",
-         n, n * LOAD_PORT_ZONE_STRIDE, remaining);
-}
-
-/**
- * Checks if the mode passed is either LOAD or SAVE.
- *
- * Called once pre-fork from check_args(); an out-of-set mode aborts
- * the process via errx() before fork happens, so dmain() is guaranteed
- * to receive a valid cli_mode_config.mode value.
- *
- * Args:
- *   @mode operating mode
- */
-static void
-check_mode(int mode)
-{
-    if ((mode != LOAD_MODE) && (mode != SAVE_MODE)) {
-        errx(EXIT_FAILURE, "Incorrect mode passed. Should be 1 (LOAD) or "
-                "2 (SAVE)\n");
-    }
-}
-
-/**
- * Entry point for the daemon.
- *
- * Args:
- *   @argc num of arguments to the application.
- *   @argv string argument list.
- *   @cli  parsed CLI bundle populated by check_args() before the
- *         daemon was forked. Mode, sub-kind, and num_entries are read
- *         directly from here instead of re-walking argv. fork() copies
- *         the entire address space (including the parent's stack frame),
- *         so the pointer is valid in the grandchild.
- *
- * Returns:
- *   0 if the daemon exits without any error. otherwise the specific error
- *   code is returned.
- */
-static int
-dmain(int argc, const char *const argv[], const struct cli_mode_config *cli)
-{
-    const char *helper_id;
-    int ret;
-    int rc = 0;
-    bool stop_flag = false;
-    bool log_open = false;
-    bool dbus_started = false;
-    bool loop_mu_inited = false;
-    struct dbus_targs dbus_server_args = {0};
-    struct save_targets *save_targets = NULL;
-
-    (void) argc;
-
-    if (argv == NULL || cli == NULL) {
-        return EINVAL;
-    }
-
-    helper_id = argv[HELPER_ID_ARG_INDEX];
-
-    // Initialise logging at default INFO level.
-    ret = init_log(INFO, helper_id);
-    if (ret != 0) {
-        return EAGAIN;   // nothing else allocated yet
-    }
-    log_open = true;
-
-    // Init configs.
-    init_lmct_config(lmct_config_path);
-
-    // set the logging level read from config.
-    set_log_level(lmct_conf.log_lvl);
-
-    LOG(INFO, "%s: Starting in mode %s", __func__,
-        mode_to_string[cli->mode]);
-    LOG(INFO, "%s: dbus address %s", __func__,
-        getenv("DBUS_SYSTEM_BUS_ADDRESS"));
-    LOG(INFO, "%s: helper id: %s", __func__, helper_id);
-    LOG(INFO, "%s: Maximum CT entries migratable: %d", __func__,
-        lmct_conf.max_entries_to_migrate);
-
-    // Initialise globals.
-    conn_store = conntrack_store_new();
-    if (conn_store == NULL) {
-        LOG(ERROR, "%s: connection_store is NULL", __func__);
-        rc = EAGAIN;
-        goto cleanup;
-    }
-
-    // Start the dbus server
-    dbus_server_args.helper_id    = helper_id;
-    dbus_server_args.stop_flag    = &stop_flag;
-    dbus_server_args.mode         = cli->mode;
-    dbus_server_args.load_targets = NULL;
-    dbus_server_args.loop         = NULL;
-    dbus_server_args.should_quit  = false;
-    ret = pthread_mutex_init(&dbus_server_args.loop_mu, NULL);
-    if (ret != 0) {
-        LOG(ERROR, "%s: failed to init loop_mu: %s", __func__, strerror(ret));
-        rc = EAGAIN;
-        goto cleanup;
-    }
-    loop_mu_inited = true;
-
-    /* In LOAD mode build the (old_zone -> new_zone) remap up-front so the
-     * dbus thread has it ready by the time the destination's Load IPC
-     * arrives. SAVE mode leaves load_targets NULL. */
-    if (cli->mode == LOAD_MODE) {
-        if (cli->load_kind == LOAD_INPUT_LEGACY) {
-            dbus_server_args.load_targets = load_targets_new_ips();
-            LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
-        } else {
-            GHashTable *remap = build_zone_remap_from_args(argv,
-                                                           cli->num_entries);
-            if (remap == NULL) {
-                LOG(ERROR, "%s: failed to build zone remap", __func__);
-                rc = EINVAL;
-                goto cleanup;
-            }
-            dbus_server_args.load_targets = load_targets_new_from_remap(remap);
-            if (dbus_server_args.load_targets == NULL) {
-                LOG(ERROR, "%s: failed to create load_targets", __func__);
-                rc = EINVAL;
-                goto cleanup;
-            }
-            LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
-                __func__, cli->num_entries);
-        }
-    }
-
-    ret = pthread_create(&dbus_server_args.tid,
-                         NULL, dbus_server_init,
-                         &dbus_server_args);
-    if (ret != 0) {
-        LOG(ERROR, "%s: dbus_server thread creation failed. %s", __func__,
-            strerror(ret));
-        rc = EAGAIN;
-        goto cleanup;
-    }
-    dbus_started = true;
-    ret = pthread_setname_np(dbus_server_args.tid, "dbus_server");
-    if (ret != 0) {
-        LOG(WARNING, "%s: Failed to set thread name \"dbus_server\". %s",
-            __func__, strerror(ret));
-    }
-
-    // Start save mode threads.
-    if (cli->mode == SAVE_MODE) {
-        if (cli->save_kind == SAVE_INPUT_IPS) {
-            GHashTable *ips_to_migrate;
-            ips_to_migrate = create_ips_ht_from_args(argv, cli->num_entries);
-            if (ips_to_migrate == NULL) {
-                rc = EINVAL;
-                goto cleanup;
-            }
-            save_targets = save_targets_new_from_ips(ips_to_migrate);
-        } else {
-            GHashTable *zones_ht =
-                create_zones_ht_from_args(argv, cli->num_entries);
-            if (zones_ht == NULL) {
-                rc = EINVAL;
-                goto cleanup;
-            }
-            save_targets = save_targets_new_from_zones(zones_ht);
-        }
-
-        ret = start_in_save_mode(save_targets, &stop_flag);
-        if (ret != 0) {
-            rc = EAGAIN;
-            /* start_in_save_mode may have left events threads running
-             * that still reference save_targets (a pre-existing issue
-             * tracked separately). Don't destroy save_targets in that
-             * case -- a small intentional leak on the abnormal-exit
-             * path is preferable to a use-after-free. */
-            save_targets = NULL;
-        }
-    }
-
-cleanup:
-    /* Tell any still-running events threads to exit. start_in_save_mode
-     * normally joins them itself, but we set this defensively to cover
-     * partial-failure paths that leave the events threads alive. */
-    stop_flag = true;
-
-    /* Wake the dbus thread on every error path so pthread_join below
-     * doesn't hang waiting for an RPC that will never arrive. On the
-     * normal success path the loop has already quit itself (via
-     * on_save -> ... -> on_clear -> g_main_loop_quit for SAVE, and
-     * on_load -> g_main_loop_quit for LOAD), so request_quit is a no-op
-     * there. */
-    if (dbus_started) {
-        if (rc != 0) {
-            dbus_server_request_quit(&dbus_server_args);
-        }
-        pthread_join(dbus_server_args.tid, NULL);
-    }
-    if (save_targets != NULL) {
-        save_targets_destroy(save_targets);
-    }
-    if (dbus_server_args.load_targets != NULL) {
-        load_targets_destroy(dbus_server_args.load_targets);
-    }
-    if (loop_mu_inited) {
-        pthread_mutex_destroy(&dbus_server_args.loop_mu);
-    }
-    if (conn_store != NULL) {
-        conntrack_store_destroy(conn_store);
-        conn_store = NULL;
-    }
-    if (log_open) {
-        close_log();
-    }
-
-    return rc;
-}
-
-static void
-err_usage(void)
-{
-    errx(EXIT_FAILURE,
-        "Usage:\n"
-        "  Legacy IP-based:\n"
-        "    SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 "
-            "<helper_id> <num_ips> <ip1> <ip2> ...\n"
-        "    LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 "
-            "<helper_id>\n"
-        "  Port/CT-zone-based:\n"
-        "    SAVE mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 2 "
-            "<helper_id> <N> <port_uuid_1> <old_ct_zone_1> ... "
-            "<port_uuid_N> <old_ct_zone_N>\n"
-        "    LOAD mode: DBUS_SYSTEM_BUS_ADDRESS=<addr> conntrack_migrator 1 "
-            "<helper_id> <N> <port_uuid_1> <old_ct_zone_1> <new_ct_zone_1> "
-            "... <port_uuid_N> <old_ct_zone_N> <new_ct_zone_N>\n"
-        "NOTE: DBUS_SYSTEM_BUS_ADDRESS env variable must be set.\n");
-}
-
-/**
- * Checks if the DBUS_SYSTEM_BUS_ADDRESS env variable is set.
- */
-static void
-check_dbus_address_env(void)
-{
-    const char *dbus_address = getenv("DBUS_SYSTEM_BUS_ADDRESS");
-    if (dbus_address == NULL || strcmp(dbus_address, "") == 0) {
-        errx(EXIT_FAILURE, "DBUS_SYSTEM_BUS_ADDRESS environment variable not "
-                "set\n");
-    }
-}
-
-/**
- * Performs checks on args when started in save mode (legacy IP form).
- *
- * Checks performed:
- * 1. Num of ip address param is present and is non-negative.
- * 2. The ip address list size matches the num of ip addresses provided.
- *
- * NOTE: this is the legacy SAVE validator, kept verbatim from the original
- * implementation. The 127-IP cap referenced in the original docstring is
- * enforced later in start_in_save_mode().
- *
- * Args:
- *   @argc num of arguments.
- *   @argv array of CLI arguments.
- */
-static void
-check_ip_save_args(int argc, const char *const argv[])
-{
-    int num_ip_addr;
-
-    if (argc < 4) {
-        errx(EXIT_FAILURE, "Number of IP addresses not present in args");
-    }
-
-    /* min_value = 0 (not 1) because num_ip_addr == 0 is the legitimate
-     * "VM has no IPv4 NICs" case. The helper rejects negatives and
-     * non-numeric input; we still need the count-vs-argc check below
-     * to catch "I declared 5 IPs but only passed 2". */
-    ensure_cli_arg_is_int_at_least(argv[NUM_IP_ADDR_ARG_INDEX], &num_ip_addr,
-                                   "num_ips", MIN_ACCEPTABLE_VALUE_FOR_NUM_IPS);
-    if (num_ip_addr > (argc - IP_ADDR_LIST_ARG_INDEX)) {
-        errx(EXIT_FAILURE,
-             "Declared num_ips (%d) exceeds the number of IP addresses "
-             "supplied in argv (%d)",
-             num_ip_addr, argc - IP_ADDR_LIST_ARG_INDEX);
-    }
-}
-
-/**
- * Per-entry content checks for the new SAVE port-zone layout.
- *
- * Arity (argc vs declared N) is guaranteed by detect_save_input_kind()
- * before we get here, so we only validate the *content* of each entry:
- *  - port_uuid is a port-prefixed canonical UUID of the form
- *    "port_<8-4-4-4-12>" (total length 41),
- *  - old_ct_zone parses cleanly as uint16.
- *
- * Aborts the process via errx() on the first malformed entry.
- *
- * Args:
- *   @argc num of arguments (used only for an arity sanity check).
- *   @argv array of CLI arguments.
- */
-static void
-check_zone_save_args(int argc, const char *const argv[])
-{
-    int n;
-    int i;
-    const int old_zone_offset = 1;
-
-    (void) argc;
-
-    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
-                                   "num_entries",
-                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
-
-    for (i = 0; i < n; i++) {
-        int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
-        const char *port_uuid = argv[base];
-        const char *zone_str  = argv[base + old_zone_offset];
-        uint16_t zone_val;
-
-        if (!is_valid_uuid_string(port_uuid)) {
-            errx(EXIT_FAILURE,
-                 "Invalid UUID at port-zone entry %d: '%s'",
-                 i, port_uuid);
-        }
-        if (!parse_ct_zone(zone_str, &zone_val)) {
-            errx(EXIT_FAILURE,
-                 "Invalid old_ct_zone at port-zone entry %d: '%s' "
-                 "(must be uint16)", i, zone_str);
-        }
-    }
-}
-
-/**
- * Per-entry content checks for the new LOAD port-zone layout.
- *
- * Arity is guaranteed by detect_load_input_kind(); we only validate the
- * content of each (port_uuid, old_ct_zone, new_ct_zone) triple.
- *
- * Args:
- *   @argc num of arguments (used only for an arity sanity check).
- *   @argv array of CLI arguments.
- */
-static void
-check_zone_load_args(int argc, const char *const argv[])
-{
-    int n;
-    int i;
-    const int old_zone_offset = 1;
-    const int new_zone_offset = 2;
-
-    (void) argc;
-
-    ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
-                                   "num_entries",
-                                   MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
-
-    for (i = 0; i < n; i++) {
-        int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
-        const char *port_uuid    = argv[base];
-        const char *old_zone_str = argv[base + old_zone_offset];
-        const char *new_zone_str = argv[base + new_zone_offset];
-        uint16_t z;
-
-        if (!is_valid_uuid_string(port_uuid)) {
-            errx(EXIT_FAILURE,
-                 "Invalid UUID at port-zone entry %d: '%s'",
-                 i, port_uuid);
-        }
-        if (!parse_ct_zone(old_zone_str, &z)) {
-            errx(EXIT_FAILURE,
-                 "Invalid old_ct_zone at port-zone entry %d: '%s'",
-                 i, old_zone_str);
-        }
-        if (!parse_ct_zone(new_zone_str, &z)) {
-            errx(EXIT_FAILURE,
-                 "Invalid new_ct_zone at port-zone entry %d: '%s'",
-                 i, new_zone_str);
-        }
-    }
-}
-
-/**
- * Top-level SAVE-mode arg dispatcher.
- *
- * Picks IP vs port-zone via detect_save_input_kind() and delegates
- * per-entry validation to the appropriate validator. Reports the
- * detected sub-kind and the declared entry count to the caller so they
- * can be recorded on cli_mode_config without an extra argv parse.
- *
- * Args:
- *   @argc          num of arguments.
- *   @argv          array of CLI arguments.
- *   @out_kind      output pointer for the detected sub-kind. May be NULL.
- *   @out_n_entries output pointer for the declared entry count, captured
- *                  from detect_save_input_kind's existing parse. May be
- *                  NULL. 0 on the SAVE-IP "no list" shortcut.
- */
-static void
-check_save_mode_args(int argc, const char *const argv[],
-                     enum save_input_kind *out_kind,
-                     int *out_n_entries)
-{
-    int n_entries = 0;
-    enum save_input_kind kind =
-        detect_save_input_kind(argc, argv, &n_entries);
-
-    if (kind == SAVE_INPUT_IPS) {
-        check_ip_save_args(argc, argv);
-    } else {
-        if (kind == SAVE_INPUT_PORT_ZONES) {
-            check_zone_save_args(argc, argv);
-        } else {
-            errx(EXIT_FAILURE, "Invalid save input kind: %d", kind);
-        }
-    }
-
-    if (out_kind != NULL) {
-        *out_kind = kind;
-    }
-    if (out_n_entries != NULL) {
-        *out_n_entries = n_entries;
-    }
-}
-
+ 
+ /**
+  * Top-level SAVE-mode arg dispatcher.
+  *
+  * Picks IP vs port-zone via detect_save_input_kind() and delegates
+  * per-entry validation to the appropriate validator. Reports the
+  * detected sub-kind and the declared entry count to the caller so they
+  * can be recorded on cli_mode_config without an extra argv parse.
+  *
+  * Args:
+  *   @argc          num of arguments.
+  *   @argv          array of CLI arguments.
+  *   @out_kind      output pointer for the detected sub-kind. May be NULL.
+  *   @out_n_entries output pointer for the declared entry count, captured
+  *                  from detect_save_input_kind's existing parse. May be
+  *                  NULL. 0 on the SAVE-IP "no list" shortcut.
+  */
+ static void
+ check_save_mode_args(int argc, const char *const argv[],
+                      enum save_input_kind *out_kind,
+                      int *out_n_entries)
+ {
+     int n_entries = 0;
+     enum save_input_kind kind =
+         detect_save_input_kind(argc, argv, &n_entries);
+ 
+     if (kind == SAVE_INPUT_IPS) {
+         check_ip_save_args(argc, argv);
+     } else {
+         if (kind == SAVE_INPUT_PORT_ZONES) {
+             check_zone_save_args(argc, argv);
+         } else {
+             errx(EXIT_FAILURE, "Invalid save input kind: %d", kind);
+         }
+     }
+ 
+     if (out_kind != NULL) {
+         *out_kind = kind;
+     }
+     if (out_n_entries != NULL) {
+         *out_n_entries = n_entries;
+     }
+ }
+ 
 /**
  * Top-level LOAD-mode arg dispatcher.
  *
  * Legacy LOAD takes no extra args beyond <mode> <helper_id>; the new LOAD
- * port-zone layout is content-validated. Reports the detected sub-kind
- * and the declared entry count to the caller so they can be recorded on
- * cli_mode_config without an extra argv parse.
+ * port-zone layout is content-validated AND the (old_zone -> new_zone)
+ * remap is built in the same pass via check_zone_load_args(). The built
+ * remap is published to the caller so dmain() can wrap it post-fork
+ * without re-walking argv.
+ *
+ * Reports the detected sub-kind and the declared entry count to the
+ * caller so they can be recorded on cli_mode_config without an extra
+ * argv parse.
  *
  * Args:
- *   @argc          num of arguments.
- *   @argv          array of CLI arguments.
- *   @out_kind      output pointer for the detected sub-kind. May be NULL.
- *   @out_n_entries output pointer for the declared entry count, captured
- *                  from detect_load_input_kind's existing parse. May be
- *                  NULL. 0 on the LOAD legacy shortcut.
+ *   @argc            num of arguments.
+ *   @argv            array of CLI arguments.
+ *   @out_kind        output pointer for the detected sub-kind. May be NULL.
+ *   @out_n_entries   output pointer for the declared entry count, captured
+ *                    from detect_load_input_kind's existing parse. May be
+ *                    NULL. 0 on the LOAD legacy shortcut.
+ *   @out_zone_remap  output pointer for the freshly built remap. May be
+ *                    NULL (caller doesn't care). Always set to NULL for
+ *                    LOAD_INPUT_LEGACY; non-NULL for LOAD_INPUT_PORT_ZONES.
+ *                    Ownership transfers to the caller.
  */
 static void
 check_load_mode_args(int argc, const char *const argv[],
                      enum load_input_kind *out_kind,
-                     int *out_n_entries)
+                     int *out_n_entries,
+                     GHashTable **out_zone_remap)
 {
     int n_entries = 0;
+    GHashTable *remap = NULL;
     enum load_input_kind kind =
         detect_load_input_kind(argc, argv, &n_entries);
 
     if (kind == LOAD_INPUT_PORT_ZONES) {
-        check_zone_load_args(argc, argv);
+        remap = check_zone_load_args(argc, argv);
     } else {
         if (kind != LOAD_INPUT_LEGACY) {
             errx(EXIT_FAILURE, "Invalid load input kind: %d", kind);
@@ -1161,133 +1144,140 @@ check_load_mode_args(int argc, const char *const argv[],
     if (out_n_entries != NULL) {
         *out_n_entries = n_entries;
     }
+    if (out_zone_remap != NULL) {
+        *out_zone_remap = remap;
+    } else if (remap != NULL) {
+        /* Caller dropped ownership; don't leak. */
+        g_hash_table_destroy(remap);
+    }
 }
-
-/**
- * Top-level CLI validation entry point.
- *
- * Checks performed:
- * 1. Minimum argc.
- * 2. DBUS_SYSTEM_BUS_ADDRESS env is set.
- * 3. Mode is valid (LOAD/SAVE).
- * 4. Per-mode argument shape and per-entry content (legacy IP form or
- *    new port-zone form, auto-detected from argv).
- *
- * On success populates @out with the validated (mode, sub-kind) pair.
- * On any failure errx() exits the process.
- *
- * Args:
- *   @argc num of arguments.
- *   @argv array of CLI arguments.
- *   @out  output struct populated with the parse result. Must be non-NULL.
- */
-static void
-check_args(int argc, const char *const argv[], struct cli_mode_config *out)
-{
-    int mode;
-
-    if (argv == NULL || out == NULL) {
-        errx(EXIT_FAILURE,
-             "%s: argv=%p out=%p (both must be non-NULL)",
-             __func__, (void *)argv, (void *)out);
-    }
-
-    if (argc < 3) {
-        err_usage();
-    }
-
-    check_dbus_address_env();
-
-    ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
-                                   MIN_ACCEPTABLE_VALUE_FOR_MODE);
-    check_mode(mode);
-    out->mode = (enum op_mode) mode;
-
-    /* num_entries is populated by the mode-specific dispatcher, which
-     * in turn picks it up from detect_*_input_kind's existing parse -
-     * no second call to ensure_cli_arg_is_int_at_least on argv[3]. */
-    if (mode == SAVE_MODE) {
-        check_save_mode_args(argc, argv, &out->save_kind,
-                             &out->num_entries);
+ 
+ /**
+  * Top-level CLI validation entry point.
+  *
+  * Checks performed:
+  * 1. Minimum argc.
+  * 2. DBUS_SYSTEM_BUS_ADDRESS env is set.
+  * 3. Mode is valid (LOAD/SAVE).
+  * 4. Per-mode argument shape and per-entry content (legacy IP form or
+  *    new port-zone form, auto-detected from argv).
+  *
+  * On success populates @out with the validated (mode, sub-kind) pair.
+  * On any failure errx() exits the process.
+  *
+  * Args:
+  *   @argc num of arguments.
+  *   @argv array of CLI arguments.
+  *   @out  output struct populated with the parse result. Must be non-NULL.
+  */
+ static void
+ check_args(int argc, const char *const argv[], struct cli_mode_config *out)
+ {
+     int mode;
+ 
+     if (argv == NULL || out == NULL) {
+         errx(EXIT_FAILURE,
+              "%s: argv=%p out=%p (both must be non-NULL)",
+              __func__, (void *)argv, (void *)out);
+     }
+ 
+     if (argc < 3) {
+         err_usage();
+     }
+ 
+     check_dbus_address_env();
+ 
+     ensure_cli_arg_is_int_at_least(argv[MODE_ARG_INDEX], &mode, "mode",
+                                    MIN_ACCEPTABLE_VALUE_FOR_MODE);
+     check_mode(mode);
+     out->mode = (enum op_mode) mode;
+ 
+     /* num_entries is populated by the mode-specific dispatcher, which
+      * in turn picks it up from detect_*_input_kind's existing parse -
+      * no second call to ensure_cli_arg_is_int_at_least on argv[3]. */
+     if (mode == SAVE_MODE) {
+         check_save_mode_args(argc, argv, &out->save_kind,
+                              &out->num_entries);
     } else {
         check_load_mode_args(argc, argv, &out->load_kind,
-                             &out->num_entries);
+                             &out->num_entries, &out->zone_remap);
     }
 }
-
-/**
- * Entry point for the conntrack_migrator application.
- *
- * This function is the entry point for the conntrack_migrator
- * application. As a first step it validates some of the arguments
- * provided and then proceeds to daemonise itself. main uses double forking
- * to turn itself into a daemon.
- * The process forks a child and waits for the child to terminate.
- * The first fork enables the child process to take control of the tty
- * session and become the process leader. At this point, the child forks
- * another process and does not wait for it to exit. Thus, the new grand-child
- * process is now orphaned and handled by the init process.
- * Thus the second fork guarantees that the child is no longer a session
- * leader, preventing the daemon from ever acquiring a controlling terminal.
- *
- * Args:
- *   @argc num of argmuments to the application
- *   @argv string argument list
- *
- * Returns:
- *   0 if the application exits without any error. otherwise the specific
- *   error code is returned.
- */
-int
-main(int argc, char *argv[])
-{
-    int child_pid;
-    struct cli_mode_config cli = {0};
-
-    /* Validate CLI args + decide IP-vs-zone sub-kind before any forks.
-     * fork() preserves the parent's address space (copy-on-write of
-     * the entire AS, including this stack frame), so `cli` is still
-     * readable in the grandchild and is passed directly to dmain()
-     * rather than being re-parsed there. */
-    check_args(argc, (const char *const *)argv, &cli);
-
-    // Fork child
-    child_pid = fork();
-    if (child_pid < 0) {
-        err(EXIT_FAILURE, "Child fork failed.\n");
-    }
-    if (child_pid == 0) {
-        // Become a process group and session group leader
-        setsid();
-        
-        // Fork granchild so that session leader can exit
-        int grandchild_pid = fork();
-        if (grandchild_pid < 0) {
-            err(EXIT_FAILURE, "grand-child fork failed.\n");
-        }
-        if (grandchild_pid == 0) {
-            int ret = 0;
-            // Grand-child process
-            chdir("/");
-
-            // Close all open file descriptors inherited from parent.
-            int x;
-            for (x = sysconf(_SC_OPEN_MAX); x >= 0; x--) {
-                close(x);
-            }
-
-            // start the daemon
-            ret = dmain(argc, (const char *const *)argv, &cli);
-            exit((ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE));
-        } else {
-            // Child process
-            printf("pid=%d\n", grandchild_pid);
-            exit(EXIT_SUCCESS);
-        }
-        exit(EXIT_SUCCESS);
-    } else {
-        // Parent process
-        wait(NULL);
-    }
-    return EXIT_SUCCESS;
-}
+ 
+ /**
+  * Entry point for the conntrack_migrator application.
+  *
+  * This function is the entry point for the conntrack_migrator
+  * application. As a first step it validates some of the arguments
+  * provided and then proceeds to daemonise itself. main uses double forking
+  * to turn itself into a daemon.
+  * The process forks a child and waits for the child to terminate.
+  * The first fork enables the child process to take control of the tty
+  * session and become the process leader. At this point, the child forks
+  * another process and does not wait for it to exit. Thus, the new grand-child
+  * process is now orphaned and handled by the init process.
+  * Thus the second fork guarantees that the child is no longer a session
+  * leader, preventing the daemon from ever acquiring a controlling terminal.
+  *
+  * Args:
+  *   @argc num of argmuments to the application
+  *   @argv string argument list
+  *
+  * Returns:
+  *   0 if the application exits without any error. otherwise the specific
+  *   error code is returned.
+  */
+ int
+ main(int argc, char *argv[])
+ {
+     int child_pid;
+     struct cli_mode_config cli = {0};
+ 
+     /* Validate CLI args + decide IP-vs-zone sub-kind before any forks.
+      * fork() preserves the parent's address space (copy-on-write of
+      * the entire AS, including this stack frame), so `cli` is still
+      * readable in the grandchild and is passed directly to dmain()
+      * rather than being re-parsed there. */
+     check_args(argc, (const char *const *)argv, &cli);
+ 
+     // Fork child
+     child_pid = fork();
+     if (child_pid < 0) {
+         err(EXIT_FAILURE, "Child fork failed.\n");
+     }
+     if (child_pid == 0) {
+         // Become a process group and session group leader
+         setsid();
+         
+         // Fork granchild so that session leader can exit
+         int grandchild_pid = fork();
+         if (grandchild_pid < 0) {
+             err(EXIT_FAILURE, "grand-child fork failed.\n");
+         }
+         if (grandchild_pid == 0) {
+             int ret = 0;
+             // Grand-child process
+             chdir("/");
+ 
+             // Close all open file descriptors inherited from parent.
+             int x;
+             for (x = sysconf(_SC_OPEN_MAX); x >= 0; x--) {
+                 close(x);
+             }
+ 
+             // start the daemon
+             ret = dmain(argc, (const char *const *)argv, &cli);
+             exit((ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE));
+         } else {
+             // Child process
+             printf("pid=%d\n", grandchild_pid);
+             exit(EXIT_SUCCESS);
+         }
+         exit(EXIT_SUCCESS);
+     } else {
+         // Parent process
+         wait(NULL);
+     }
+     return EXIT_SUCCESS;
+ }
+ 

--- a/src/main.c
+++ b/src/main.c
@@ -107,10 +107,11 @@ const char *mode_to_string[] = {
 
 struct ct_delete_args ct_del_args = {
     .kind = SAVE_INPUT_IPS,       /* overwritten in start_in_save_mode */
+    /* Only the active union arm is named; the other arm overlays the
+     * same memory and is zero-initialised by the {0} default. Naming
+     * both arms here would trip -Woverride-init. */
     .ips_migrated = NULL,
     .ips_on_host = NULL,
-    .zones_migrated = NULL,
-    .zones_on_host = NULL,
     .clear_called = false,
     .mutex = PTHREAD_MUTEX_INITIALIZER,
     .clear_called_cond = PTHREAD_COND_INITIALIZER

--- a/src/main.c
+++ b/src/main.c
@@ -79,7 +79,7 @@
  
 /* Per-entry argv stride for the legacy IP layout and the new
  * (port_uuid, ct_zone[, new_ct_zone]) layout. IP_STRIDE is named (not
- * inlined as 1) so detect_save_input_kind() reads symmetrically against
+ * inlined as 1) so detect_save_mode_op_type() reads symmetrically against
  * its port-zone peer and the shape-mismatch error message is self-explanatory. */
 #define IP_STRIDE                       1   /* <ip> */
 #define SAVE_PORT_ZONE_STRIDE           2   /* <port_uuid> <old_ct_zone> */
@@ -94,28 +94,28 @@
   * space (including main's stack frame), so the struct is valid in the
   * grandchild and is read verbatim.
   *
-  * The sub-kind field is a tagged union: the active arm is determined by
-  * @mode (SAVE_MODE -> save_kind, LOAD_MODE -> load_kind).
-  *
-  * @num_entries holds the declared entry count from
-  * argv[NUM_ENTRIES_ARG_INDEX] when applicable:
-  *   - SAVE IP-mode "no IPv4 NICs" path  (argc <= 4):  0
-  *   - SAVE IP-mode standard:                          num_ips
-  *   - SAVE port-zone mode:                            N
-  *   - LOAD legacy:                                    0
-  *   - LOAD port-zone mode:                            N
-  * Consumers that legitimately accept 0 (the no-IPv4-NICs path) must
-  * treat 0 as "list absent" rather than "list empty bad".
-  *
-  * num_entries is captured by detect_*_input_kind during its existing
-  * shape-detection parse and propagated up through check_*_mode_args -
-  * check_args does not parse argv[3] a second time.
-  */
+ * The sub-op_type field is a tagged union: the active arm is determined by
+ * @mode (SAVE_MODE -> save_op_type, LOAD_MODE -> load_op_type).
+ *
+ * @num_entries holds the declared entry count from
+ * argv[NUM_ENTRIES_ARG_INDEX] when applicable:
+ *   - SAVE IP-mode "no IPv4 NICs" path  (argc <= 4):  0
+ *   - SAVE IP-mode standard:                          num_ips
+ *   - SAVE port-zone mode:                            N
+ *   - LOAD legacy:                                    0
+ *   - LOAD port-zone mode:                            N
+ * Consumers that legitimately accept 0 (the no-IPv4-NICs path) must
+ * treat 0 as "list absent" rather than "list empty bad".
+ *
+ * num_entries is captured by detect_*_mode_op_type during its existing
+ * shape-detection parse and propagated up through check_*_mode_args -
+ * check_args does not parse argv[3] a second time.
+ */
 struct cli_mode_config {
     enum op_mode mode;
     union {
-        enum save_input_kind save_kind;
-        enum load_input_kind load_kind;
+        enum save_mode_op_type save_op_type;
+        enum load_mode_op_type load_op_type;
     };
     int num_entries;
     /* LOAD-port-zone mode only: (old_zone -> new_zone) src-to-dst zone
@@ -136,7 +136,7 @@ struct cli_mode_config {
  };
  
  struct ct_delete_args ct_del_args = {
-     .kind = SAVE_INPUT_IPS,       /* overwritten in start_in_save_mode */
+     .op_type = SAVE_IPS_OP,       /* overwritten in start_in_save_mode */
      /* Only the active union arm is named; the other arm overlays the
       * same memory and is zero-initialised by the {0} default. Naming
       * both arms here would trip -Woverride-init. */
@@ -163,8 +163,8 @@ struct cli_mode_config {
      struct mnl_socket *nl;
  
     targs = (struct ct_events_targs *) data;
-    LOG(INFO, "%s: Starting conntrack events thread. kind=%s is_src=%d",
-        __func__, save_input_kind_to_string(targs->save_config->kind),
+    LOG(INFO, "%s: Starting conntrack events thread. op_type=%s is_src=%d",
+        __func__, convert_save_mode_op_type_to_string(targs->save_config->op_type),
         targs->is_src);
 
     nl = mnl_socket_open(NETLINK_NETFILTER);
@@ -188,8 +188,8 @@ struct cli_mode_config {
                                 targs->is_src, targs->stop_flag);
     mnl_socket_close(nl);
 
-    LOG(INFO, "%s: Finished conntrack events thread. kind=%s is_src=%d",
-        __func__, save_input_kind_to_string(targs->save_config->kind),
+    LOG(INFO, "%s: Finished conntrack events thread. op_type=%s is_src=%d",
+        __func__, convert_save_mode_op_type_to_string(targs->save_config->op_type),
         targs->is_src);
 
     return NULL;
@@ -272,7 +272,7 @@ create_events_thread(struct save_mode_config *save_config, bool *stop_flag,
  /**
   * Spawn the conntrack delete thread.
   *
-  * Mode-aware via ct_del_args.kind and the migrated-set pointers the
+  * Mode-aware via ct_del_args.op_type and the migrated-set pointers the
   * caller has already populated on ct_del_args before this call. The
   * thread is started in BOTH save sub-modes; its lifetime is what
   * keeps the DBus main loop responsive to on_clear until the Clear
@@ -309,7 +309,7 @@ create_events_thread(struct save_mode_config *save_config, bool *stop_flag,
   * Following things are performed in the save mode:
   * 1. Conntrack delete thread is started which waits till Clear IPC is
   *    called. The thread is started in both IP and zone sub-modes; it
-  *    dispatches on ct_del_args.kind when it wakes up.
+  *    dispatches on ct_del_args.op_type when it wakes up.
   * 2. Conntrack events threads are started to filter events for the
   *    migration targets. In IP mode this is two BPF-filtered threads
   *    (one src, one dst). In zone mode BPF can't filter on CT zone, so a
@@ -345,20 +345,20 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
      * error in either mode (e.g. a VM with no IPv4 NICs in IP mode);
      * QEMU expects the helper to live for the migration window, so we
      * just skip starting the worker threads and let the DBus loop run. */
-    if (save_config->kind == SAVE_INPUT_IPS) {
+    if (save_config->op_type == SAVE_IPS_OP) {
         num_entries = g_hash_table_size(save_config->ips_to_migrate);
     } else {
         num_entries = g_hash_table_size(save_config->zones_to_migrate);
     }
     if (num_entries == 0) {
-        LOG(INFO, "%s: No entries to migrate (kind=%s); skipping save "
+        LOG(INFO, "%s: No entries to migrate (op_type=%s); skipping save "
             "mode threads", __func__,
-            save_input_kind_to_string(save_config->kind));
+            convert_save_mode_op_type_to_string(save_config->op_type));
         return 0;
     }
     /* IP-only: BPF filter cap. Zone mode does in-callback matching so
      * the per-IP limit does not apply. */
-    if (save_config->kind == SAVE_INPUT_IPS &&
+    if (save_config->op_type == SAVE_IPS_OP &&
         num_entries > MAX_IP_ADDRESSES_SUPPORTED) {
         LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
             "No Conntrack Migration will be performed.",
@@ -368,10 +368,10 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
 
     /* Common: wire up the delete-thread state, then create the thread.
      * The delete thread is started in BOTH modes; the body of
-     * _delete_ct_entries dispatches on kind when on_clear wakes it up.
+     * _delete_ct_entries dispatches on op_type when on_clear wakes it up.
      * NOTE: ct_del_args is an extern global. */
-    ct_del_args.kind = save_config->kind;
-    if (save_config->kind == SAVE_INPUT_IPS) {
+    ct_del_args.op_type = save_config->op_type;
+    if (save_config->op_type == SAVE_IPS_OP) {
         ct_del_args.ips_migrated = save_config->ips_to_migrate;
     } else {
         ct_del_args.zones_migrated = save_config->zones_to_migrate;
@@ -384,7 +384,7 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
      * BPF-filtered threads (src + dst). Zone mode runs one unfiltered
      * thread; the callback handles zone matching in-process because
      * BPF cannot filter on CT zone. */
-    if (save_config->kind == SAVE_INPUT_IPS) {
+    if (save_config->op_type == SAVE_IPS_OP) {
         if (create_events_thread(save_config, stop_flag, true,
                                  "ct_events_src", &src_targs) != 0) {
             goto cleanup_delete_thread;
@@ -404,7 +404,7 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
      * thread in that order so on_clear can drive the shutdown. */
     dump_conntrack(save_config);
 
-    if (save_config->kind == SAVE_INPUT_IPS) {
+    if (save_config->op_type == SAVE_IPS_OP) {
         pthread_join(src_targs->tid, NULL);
         pthread_join(dst_targs->tid, NULL);
         g_free(src_targs);
@@ -520,13 +520,13 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
   * number of trailing argv slots against the declared entry count N:
   *
   *   ratio = (argc - ENTRIES_LIST_START_ARG_INDEX) / N
-  *     ratio == 1 -> SAVE_INPUT_IPS         (one IP per entry)
-  *     ratio == 2 -> SAVE_INPUT_PORT_ZONES  (port_uuid + old_zone per entry)
+  *     ratio == 1 -> SAVE_IPS_OP        (one IP per entry)
+  *     ratio == 2 -> SAVE_PORT_ZONE_OP  (port_uuid + old_zone per entry)
   *
-  * The "no list / N == 0" cases default to SAVE_INPUT_IPS so the existing
+  * The "no list / N == 0" cases default to SAVE_IPS_OP so the existing
   * "VM with no IPv4 NICs" passthrough in start_in_save_mode() stays intact.
   *
-  * Called once pre-fork from check_save_mode_args(); the detected kind
+  * Called once pre-fork from check_save_mode_args(); the detected op_type
   * and declared N are recorded on cli_mode_config and read by dmain()
   * after the double fork rather than re-detected.
   *
@@ -541,15 +541,15 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
   *   The detected sub-mode. Aborts the process via errx() on a shape
   *   mismatch (declared N is non-zero but trailing args fit neither layout).
   */
- static enum save_input_kind
- detect_save_input_kind(int argc, const char *const argv[], int *out_n_entries)
+ static enum save_mode_op_type
+ detect_save_mode_op_type(int argc, const char *const argv[], int *out_n_entries)
  {
      int n;
      int remaining;
  
      if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
          *out_n_entries = 0;
-         return SAVE_INPUT_IPS;
+         return SAVE_IPS_OP;
      }
  
      ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n,
@@ -560,10 +560,10 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
     remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
 
     if (remaining == n * IP_STRIDE) {
-        return SAVE_INPUT_IPS;
+        return SAVE_IPS_OP;
     }
     if (remaining == n * SAVE_PORT_ZONE_STRIDE) {
-        return SAVE_INPUT_PORT_ZONES;
+        return SAVE_PORT_ZONE_OP;
     }
 
     errx(EXIT_FAILURE,
@@ -583,10 +583,10 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
   * Anything else is a hard error - we deliberately do NOT silently fall back
   * to legacy if the trailing args do not match the new shape.
   *
-  * Called once pre-fork from check_load_mode_args(); the detected kind
+  * Called once pre-fork from check_load_mode_args(); the detected op_type
   * and declared N are recorded on cli_mode_config and read by dmain()
   * after the double fork rather than re-detected (mirroring
-  * detect_save_input_kind above).
+  * detect_save_mode_op_type above).
   *
   * Args:
   *   @argc           num of CLI arguments.
@@ -598,15 +598,15 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
   * Returns:
   *   The detected sub-mode. Aborts the process via errx() on any mismatch.
   */
- static enum load_input_kind
- detect_load_input_kind(int argc, const char *const argv[], int *out_n_entries)
+ static enum load_mode_op_type
+ detect_load_mode_op_type(int argc, const char *const argv[], int *out_n_entries)
  {
      int n;
      int remaining;
  
      if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
          *out_n_entries = 0;
-         return LOAD_INPUT_LEGACY;
+         return LOAD_IPS_OP;
      }
  
      if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
@@ -625,7 +625,7 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
      remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
  
      if (remaining == n * LOAD_PORT_ZONE_STRIDE) {
-         return LOAD_INPUT_PORT_ZONES;
+         return LOAD_PORT_ZONE_OP;
      }
  
      errx(EXIT_FAILURE,
@@ -660,7 +660,7 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
   *   @argc num of arguments to the application.
   *   @argv string argument list.
   *   @cli  parsed CLI bundle populated by check_args() before the
-  *         daemon was forked. Mode, sub-kind, and num_entries are read
+  *         daemon was forked. Mode, sub-op_type, and num_entries are read
   *         directly from here instead of re-walking argv. fork() copies
   *         the entire address space (including the parent's stack frame),
   *         so the pointer is valid in the grandchild.
@@ -720,13 +720,13 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
      }
  
     // Start the dbus server
-    dbus_server_args.helper_id    = helper_id;
-    dbus_server_args.stop_flag    = &stop_flag;
-    dbus_server_args.mode         = cli->mode;
-    dbus_server_args.save_kind    = cli->save_kind; /* unused in LOAD; on_save reads it */
-    dbus_server_args.load_config  = NULL;
-    dbus_server_args.loop         = NULL;
-    dbus_server_args.should_quit  = false;
+   dbus_server_args.helper_id          = helper_id;
+   dbus_server_args.stop_flag          = &stop_flag;
+   dbus_server_args.mode               = cli->mode;
+   dbus_server_args.save_op_type  = cli->save_op_type; /* unused in LOAD; on_save reads it */
+   dbus_server_args.load_config        = NULL;
+   dbus_server_args.loop               = NULL;
+   dbus_server_args.should_quit        = false;
      ret = pthread_mutex_init(&dbus_server_args.loop_mu, NULL);
      if (ret != 0) {
          LOG(ERROR, "%s: failed to init loop_mu: %s", __func__, strerror(ret));
@@ -741,11 +741,11 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
     * pre-fork in check_zone_load_args() and rides through fork() in
     * cli->src_dst_zone_map via COW of the parent's address space.
     * SAVE mode and LOAD-legacy mode leave src_dst_zone_map NULL. */
-   if (cli->mode == LOAD_MODE) {
-       if (cli->load_kind == LOAD_INPUT_LEGACY) {
-           dbus_server_args.load_config =
-               create_load_mode_config_for_legacy_mode();
-           LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
+  if (cli->mode == LOAD_MODE) {
+      if (cli->load_op_type == LOAD_IPS_OP) {
+          dbus_server_args.load_config =
+              create_load_mode_config_for_legacy_mode();
+          LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
        } else {
            dbus_server_args.load_config =
                create_load_mode_config_for_port_zone_mode(cli->src_dst_zone_map);
@@ -776,8 +776,8 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
      }
  
     // Start save mode threads.
-    if (cli->mode == SAVE_MODE) {
-        if (cli->save_kind == SAVE_INPUT_IPS) {
+   if (cli->mode == SAVE_MODE) {
+       if (cli->save_op_type == SAVE_IPS_OP) {
             GHashTable *ips_to_migrate;
             ips_to_migrate = create_ips_ht_from_args(argv, cli->num_entries);
             if (ips_to_migrate == NULL) {
@@ -919,8 +919,8 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
  /**
   * Per-entry content checks for the new SAVE port-zone layout.
   *
-  * Arity (argc vs declared N) is guaranteed by detect_save_input_kind()
-  * before we get here, so we only validate the *content* of each entry:
+ * Arity (argc vs declared N) is guaranteed by detect_save_mode_op_type()
+ * before we get here, so we only validate the *content* of each entry:
   *  - port_uuid is a port-prefixed canonical UUID of the form
   *    "port_<8-4-4-4-12>" (total length 41),
   *  - old_ct_zone parses cleanly as uint16.
@@ -968,7 +968,7 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
  * with the (old_zone -> new_zone) src-to-dst zone map build into a
  * single argv pass.
  *
- * Arity is guaranteed by detect_load_input_kind(); we validate the content
+ * Arity is guaranteed by detect_load_mode_op_type(); we validate the content
  * of each (port_uuid, old_ct_zone, new_ct_zone) triple and, on success,
  * insert (old_zone -> new_zone) into a freshly allocated hashtable.
  * Returning the map directly (instead of validating now and reparsing
@@ -1059,40 +1059,40 @@ check_zone_load_args(int argc, const char *const argv[])
  /**
   * Top-level SAVE-mode arg dispatcher.
   *
-  * Picks IP vs port-zone via detect_save_input_kind() and delegates
-  * per-entry validation to the appropriate validator. Reports the
-  * detected sub-kind and the declared entry count to the caller so they
-  * can be recorded on cli_mode_config without an extra argv parse.
-  *
-  * Args:
-  *   @argc          num of arguments.
-  *   @argv          array of CLI arguments.
-  *   @out_kind      output pointer for the detected sub-kind. May be NULL.
-  *   @out_n_entries output pointer for the declared entry count, captured
-  *                  from detect_save_input_kind's existing parse. May be
-  *                  NULL. 0 on the SAVE-IP "no list" shortcut.
-  */
+ * Picks IP vs port-zone via detect_save_mode_op_type() and delegates
+ * per-entry validation to the appropriate validator. Reports the
+ * detected sub-op_type and the declared entry count to the caller so they
+ * can be recorded on cli_mode_config without an extra argv parse.
+ *
+ * Args:
+ *   @argc          num of arguments.
+ *   @argv          array of CLI arguments.
+ *   @out_op_type   output pointer for the detected sub-op_type. May be NULL.
+ *   @out_n_entries output pointer for the declared entry count, captured
+ *                  from detect_save_mode_op_type's existing parse. May be
+ *                  NULL. 0 on the SAVE-IP "no list" shortcut.
+ */
  static void
  check_save_mode_args(int argc, const char *const argv[],
-                      enum save_input_kind *out_kind,
+                      enum save_mode_op_type *out_op_type,
                       int *out_n_entries)
  {
      int n_entries = 0;
-     enum save_input_kind kind =
-         detect_save_input_kind(argc, argv, &n_entries);
+     enum save_mode_op_type op_type =
+         detect_save_mode_op_type(argc, argv, &n_entries);
  
-     if (kind == SAVE_INPUT_IPS) {
+     if (op_type == SAVE_IPS_OP) {
          check_ip_save_args(argc, argv);
      } else {
-         if (kind == SAVE_INPUT_PORT_ZONES) {
+         if (op_type == SAVE_PORT_ZONE_OP) {
              check_zone_save_args(argc, argv);
          } else {
-             errx(EXIT_FAILURE, "Invalid save input kind: %d", kind);
+             errx(EXIT_FAILURE, "Invalid save mode op_type: %d", op_type);
          }
      }
  
-     if (out_kind != NULL) {
-         *out_kind = kind;
+     if (out_op_type != NULL) {
+         *out_op_type = op_type;
      }
      if (out_n_entries != NULL) {
          *out_n_entries = n_entries;
@@ -1108,43 +1108,43 @@ check_zone_load_args(int argc, const char *const argv[])
  * The built map is published to the caller so dmain() can wrap it
  * post-fork without re-walking argv.
  *
- * Reports the detected sub-kind and the declared entry count to the
+ * Reports the detected sub-op_type and the declared entry count to the
  * caller so they can be recorded on cli_mode_config without an extra
  * argv parse.
  *
  * Args:
  *   @argc                num of arguments.
  *   @argv                array of CLI arguments.
- *   @out_kind            output pointer for the detected sub-kind. May be NULL.
+ *   @out_op_type         output pointer for the detected sub-op_type. May be NULL.
  *   @out_n_entries       output pointer for the declared entry count, captured
- *                        from detect_load_input_kind's existing parse. May be
+ *                        from detect_load_mode_op_type's existing parse. May be
  *                        NULL. 0 on the LOAD legacy shortcut.
  *   @out_src_dst_zone_map output pointer for the freshly built src-to-dst
  *                        zone map. May be NULL (caller doesn't care). Always
- *                        set to NULL for LOAD_INPUT_LEGACY; non-NULL for
- *                        LOAD_INPUT_PORT_ZONES. Ownership transfers to the caller.
+ *                        set to NULL for LOAD_IPS_OP; non-NULL for
+ *                        LOAD_PORT_ZONE_OP. Ownership transfers to the caller.
  */
 static void
 check_load_mode_args(int argc, const char *const argv[],
-                     enum load_input_kind *out_kind,
+                     enum load_mode_op_type *out_op_type,
                      int *out_n_entries,
                      GHashTable **out_src_dst_zone_map)
 {
     int n_entries = 0;
     GHashTable *src_dst_zone_map = NULL;
-    enum load_input_kind kind =
-        detect_load_input_kind(argc, argv, &n_entries);
+    enum load_mode_op_type op_type =
+        detect_load_mode_op_type(argc, argv, &n_entries);
 
-    if (kind == LOAD_INPUT_PORT_ZONES) {
+    if (op_type == LOAD_PORT_ZONE_OP) {
         src_dst_zone_map = check_zone_load_args(argc, argv);
     } else {
-        if (kind != LOAD_INPUT_LEGACY) {
-            errx(EXIT_FAILURE, "Invalid load input kind: %d", kind);
+        if (op_type != LOAD_IPS_OP) {
+            errx(EXIT_FAILURE, "Invalid load mode op_type: %d", op_type);
         }
     }
 
-    if (out_kind != NULL) {
-        *out_kind = kind;
+    if (out_op_type != NULL) {
+        *out_op_type = op_type;
     }
     if (out_n_entries != NULL) {
         *out_n_entries = n_entries;
@@ -1167,7 +1167,7 @@ check_load_mode_args(int argc, const char *const argv[],
   * 4. Per-mode argument shape and per-entry content (legacy IP form or
   *    new port-zone form, auto-detected from argv).
   *
-  * On success populates @out with the validated (mode, sub-kind) pair.
+  * On success populates @out with the validated (mode, sub-op_type) pair.
   * On any failure errx() exits the process.
   *
   * Args:
@@ -1197,16 +1197,16 @@ check_load_mode_args(int argc, const char *const argv[],
      check_mode(mode);
      out->mode = (enum op_mode) mode;
  
-     /* num_entries is populated by the mode-specific dispatcher, which
-      * in turn picks it up from detect_*_input_kind's existing parse -
-      * no second call to ensure_cli_arg_is_int_at_least on argv[3]. */
-     if (mode == SAVE_MODE) {
-         check_save_mode_args(argc, argv, &out->save_kind,
-                              &out->num_entries);
-    } else {
-        check_load_mode_args(argc, argv, &out->load_kind,
-                             &out->num_entries, &out->src_dst_zone_map);
-    }
+    /* num_entries is populated by the mode-specific dispatcher, which
+     * in turn picks it up from detect_*_mode_op_type's existing parse -
+     * no second call to ensure_cli_arg_is_int_at_least on argv[3]. */
+    if (mode == SAVE_MODE) {
+        check_save_mode_args(argc, argv, &out->save_op_type,
+                             &out->num_entries);
+   } else {
+       check_load_mode_args(argc, argv, &out->load_op_type,
+                            &out->num_entries, &out->src_dst_zone_map);
+   }
 }
  
  /**
@@ -1238,7 +1238,7 @@ check_load_mode_args(int argc, const char *const argv[],
      int child_pid;
      struct cli_mode_config cli = {0};
  
-     /* Validate CLI args + decide IP-vs-zone sub-kind before any forks.
+     /* Validate CLI args + decide IP-vs-zone sub-op_type before any forks.
       * fork() preserves the parent's address space (copy-on-write of
       * the entire AS, including this stack frame), so `cli` is still
       * readable in the grandchild and is passed directly to dmain()

--- a/src/main.c
+++ b/src/main.c
@@ -433,10 +433,10 @@ cleanup_delete_thread:
  *   Resulting hashtable containing IP address(uint32_t) as key.
  */
 static GHashTable *
-create_ips_ht_from_args(char *argv[], int num_ips)
+create_ips_ht_from_args(const char *const argv[], int num_ips)
 {
     GHashTable *ht;
-    const char **ips = (const char **)(argv + IP_ADDR_LIST_ARG_INDEX);
+    const char *const *ips = argv + IP_ADDR_LIST_ARG_INDEX;
 
     ht = create_hashtable_from_ip_list(ips, num_ips);
     if (ht == NULL) {
@@ -466,7 +466,7 @@ create_ips_ht_from_args(char *argv[], int num_ips)
  *   zones_to_migrate hashtable on success, NULL on failure.
  */
 static GHashTable *
-create_zones_ht_from_args(char *argv[], int n_entries)
+create_zones_ht_from_args(const char *const argv[], int n_entries)
 {
     int i;
     const char **zones;
@@ -526,7 +526,7 @@ create_zones_ht_from_args(char *argv[], int n_entries)
  *   failure (partially-built remap is torn down before returning).
  */
 static GHashTable *
-build_zone_remap_from_args(char *argv[], int n_entries)
+build_zone_remap_from_args(const char *const argv[], int n_entries)
 {
     GHashTable *remap;
     int i;
@@ -608,7 +608,7 @@ build_zone_remap_from_args(char *argv[], int n_entries)
  *   mismatch (declared N is non-zero but trailing args fit neither layout).
  */
 static enum save_input_kind
-detect_save_input_kind(int argc, char *argv[], int *out_n_entries)
+detect_save_input_kind(int argc, const char *const argv[], int *out_n_entries)
 {
     int n;
     int remaining;
@@ -665,7 +665,7 @@ detect_save_input_kind(int argc, char *argv[], int *out_n_entries)
  *   The detected sub-mode. Aborts the process via errx() on any mismatch.
  */
 static enum load_input_kind
-detect_load_input_kind(int argc, char *argv[], int *out_n_entries)
+detect_load_input_kind(int argc, const char *const argv[], int *out_n_entries)
 {
     int n;
     int remaining;
@@ -736,7 +736,7 @@ check_mode(int mode)
  *   code is returned.
  */
 static int
-dmain(int argc, char *argv[], const struct cli_mode_config *cli)
+dmain(int argc, const char *const argv[], const struct cli_mode_config *cli)
 {
     const char *helper_id;
     int ret;
@@ -961,7 +961,7 @@ check_dbus_address_env(void)
  *   @argv array of CLI arguments.
  */
 static void
-check_ip_save_args(int argc, char *argv[])
+check_ip_save_args(int argc, const char *const argv[])
 {
     int num_ip_addr;
 
@@ -999,7 +999,7 @@ check_ip_save_args(int argc, char *argv[])
  *   @argv array of CLI arguments.
  */
 static void
-check_zone_save_args(int argc, char *argv[])
+check_zone_save_args(int argc, const char *const argv[])
 {
     int n;
     int i;
@@ -1041,7 +1041,7 @@ check_zone_save_args(int argc, char *argv[])
  *   @argv array of CLI arguments.
  */
 static void
-check_zone_load_args(int argc, char *argv[])
+check_zone_load_args(int argc, const char *const argv[])
 {
     int n;
     int i;
@@ -1096,7 +1096,7 @@ check_zone_load_args(int argc, char *argv[])
  *                  NULL. 0 on the SAVE-IP "no list" shortcut.
  */
 static void
-check_save_mode_args(int argc, char *argv[],
+check_save_mode_args(int argc, const char *const argv[],
                      enum save_input_kind *out_kind,
                      int *out_n_entries)
 {
@@ -1139,7 +1139,7 @@ check_save_mode_args(int argc, char *argv[],
  *                  NULL. 0 on the LOAD legacy shortcut.
  */
 static void
-check_load_mode_args(int argc, char *argv[],
+check_load_mode_args(int argc, const char *const argv[],
                      enum load_input_kind *out_kind,
                      int *out_n_entries)
 {
@@ -1182,7 +1182,7 @@ check_load_mode_args(int argc, char *argv[],
  *   @out  output struct populated with the parse result. Must be non-NULL.
  */
 static void
-check_args(int argc, char *argv[], struct cli_mode_config *out)
+check_args(int argc, const char *const argv[], struct cli_mode_config *out)
 {
     int mode;
 
@@ -1249,7 +1249,7 @@ main(int argc, char *argv[])
      * the entire AS, including this stack frame), so `cli` is still
      * readable in the grandchild and is passed directly to dmain()
      * rather than being re-parsed there. */
-    check_args(argc, argv, &cli);
+    check_args(argc, (const char *const *)argv, &cli);
 
     // Fork child
     child_pid = fork();
@@ -1277,7 +1277,7 @@ main(int argc, char *argv[])
             }
 
             // start the daemon
-            ret = dmain(argc, argv, &cli);
+            ret = dmain(argc, (const char *const *)argv, &cli);
             exit((ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE));
         } else {
             // Child process

--- a/src/main.c
+++ b/src/main.c
@@ -489,6 +489,69 @@ detect_save_input_kind(int argc, char *argv[])
 }
 
 /**
+ * Decides which LOAD-mode CLI layout we are looking at.
+ *
+ * Legacy LOAD is strictly: `conntrack_migrator 1 <helper_id>` (argc == 3).
+ * New LOAD is:             `conntrack_migrator 1 <helper_id> <N>
+ *                              <port_uuid> <old_ct_zone> <new_ct_zone> ...`
+ *                          (argc == 4 + 3*N).
+ *
+ * Anything else is a hard error - we deliberately do NOT silently fall back
+ * to legacy if the trailing args do not match the new shape.
+ *
+ * NOTE: this lives in the runtime (post-fork) section of the file, above
+ * dmain(), because dmain re-runs the detection after the double fork to
+ * recover the LOAD sub-kind without threading it through a new parameter.
+ * The pre-fork validator block below uses the same function for shape
+ * checking; we deliberately keep one definition shared by both call sites
+ * (mirroring detect_save_input_kind above).
+ *
+ * Args:
+ *   @argc num of CLI arguments.
+ *   @argv array of CLI arguments.
+ *
+ * Returns:
+ *   The detected sub-mode. Aborts the process via errx() on any mismatch.
+ */
+static enum load_input_kind
+detect_load_input_kind(int argc, char *argv[])
+{
+    int n;
+    int remaining;
+
+    if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
+        return LOAD_INPUT_LEGACY;
+    }
+
+    if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
+        errx(EXIT_FAILURE,
+             "LOAD mode: trailing args present but no port-zone list. "
+             "Expected `conntrack_migrator 1 <helper_id>` or "
+             "`conntrack_migrator 1 <helper_id> <N> "
+             "<port_uuid> <old_zone> <new_zone> ...`.");
+    }
+
+    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+    if (n <= 0) {
+        errx(EXIT_FAILURE,
+             "LOAD mode: invalid number of port-zone entries: '%s' "
+             "(must be a positive integer).",
+             argv[NUM_ENTRIES_ARG_INDEX]);
+    }
+
+    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
+
+    if (remaining == n * LOAD_PORT_ZONE_STRIDE) {
+        return LOAD_INPUT_PORT_ZONES;
+    }
+
+    errx(EXIT_FAILURE,
+         "LOAD mode: argv shape mismatch. N=%d, expected %d args "
+         "(port-zone form), got %d.",
+         n, n * LOAD_PORT_ZONE_STRIDE, remaining);
+}
+
+/**
  * Entry point for the daemon.
  *
  * Args:
@@ -547,9 +610,35 @@ dmain(int argc, char *argv[])
     }
 
     // Start the dbus server
-    dbus_server_args.helper_id = helper_id;
-    dbus_server_args.stop_flag = &stop_flag;
-    dbus_server_args.mode = (enum op_mode) mode;
+    dbus_server_args.helper_id    = helper_id;
+    dbus_server_args.stop_flag    = &stop_flag;
+    dbus_server_args.mode         = (enum op_mode) mode;
+    dbus_server_args.load_targets = NULL;
+
+    /* In LOAD mode build the (old_zone -> new_zone) remap up-front so the
+     * dbus thread has it ready by the time the destination's Load IPC
+     * arrives. SAVE mode leaves load_targets NULL. */
+    if (mode == LOAD_MODE) {
+        enum load_input_kind load_kind = detect_load_input_kind(argc, argv);
+
+        if (load_kind == LOAD_INPUT_LEGACY) {
+            dbus_server_args.load_targets = load_targets_new_ips();
+            LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
+        } else {
+            int n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
+            dbus_server_args.load_targets =
+                load_targets_new_from_zone_args(n, argv,
+                                                ENTRIES_LIST_START_ARG_INDEX,
+                                                LOAD_PORT_ZONE_STRIDE);
+            if (dbus_server_args.load_targets == NULL) {
+                LOG(ERROR, "%s: failed to build load_targets", __func__);
+                return EINVAL;
+            }
+            LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
+                __func__, n);
+        }
+    }
+
     ret = pthread_create(&dbus_server_args.tid,
                          NULL, dbus_server_init,
                          &dbus_server_args);
@@ -595,65 +684,10 @@ dmain(int argc, char *argv[])
 
     pthread_join(dbus_server_args.tid, NULL);
     conntrack_store_destroy(conn_store);
+    load_targets_destroy(dbus_server_args.load_targets);
     close_log();
 
     return 0;
-}
-
-/**
- * Decides which LOAD-mode CLI layout we are looking at.
- *
- * Legacy LOAD is strictly: `conntrack_migrator 1 <helper_id>` (argc == 3).
- * New LOAD is:             `conntrack_migrator 1 <helper_id> <N>
- *                              <port_uuid> <old_ct_zone> <new_ct_zone> ...`
- *                          (argc == 4 + 3*N).
- *
- * Anything else is a hard error - we deliberately do NOT silently fall back
- * to legacy if the trailing args do not match the new shape.
- *
- * Args:
- *   @argc num of CLI arguments.
- *   @argv array of CLI arguments.
- *
- * Returns:
- *   The detected sub-mode. Aborts the process via errx() on any mismatch.
- */
-static enum load_input_kind
-detect_load_input_kind(int argc, char *argv[])
-{
-    int n;
-    int remaining;
-
-    if (argc == HELPER_ID_ARG_INDEX + 1) {   /* argc == 3: legacy LOAD */
-        return LOAD_INPUT_LEGACY;
-    }
-
-    if (argc <= ENTRIES_LIST_START_ARG_INDEX) {
-        errx(EXIT_FAILURE,
-             "LOAD mode: trailing args present but no port-zone list. "
-             "Expected `conntrack_migrator 1 <helper_id>` or "
-             "`conntrack_migrator 1 <helper_id> <N> "
-             "<port_uuid> <old_zone> <new_zone> ...`.");
-    }
-
-    n = atoi(argv[NUM_ENTRIES_ARG_INDEX]);
-    if (n <= 0) {
-        errx(EXIT_FAILURE,
-             "LOAD mode: invalid number of port-zone entries: '%s' "
-             "(must be a positive integer).",
-             argv[NUM_ENTRIES_ARG_INDEX]);
-    }
-
-    remaining = argc - ENTRIES_LIST_START_ARG_INDEX;
-
-    if (remaining == n * LOAD_PORT_ZONE_STRIDE) {
-        return LOAD_INPUT_PORT_ZONES;
-    }
-
-    errx(EXIT_FAILURE,
-         "LOAD mode: argv shape mismatch. N=%d, expected %d args "
-         "(port-zone form), got %d.",
-         n, n * LOAD_PORT_ZONE_STRIDE, remaining);
 }
 
 static void

--- a/src/main.c
+++ b/src/main.c
@@ -415,45 +415,40 @@ create_ips_ht_from_args(char *argv[])
 }
 
 /**
- * Creates the (zones_to_migrate, ports_to_migrate) hashtable pair from the
- * SAVE port-zone CLI arguments.
+ * Creates the zones_to_migrate hashtable from the SAVE port-zone CLI
+ * arguments.
  *
- * Walks argv at the SAVE_PORT_ZONE_STRIDE-strided offsets, splits out the
- * port_uuid and old_ct_zone columns, and hands the parallel arrays to
- * create_hashtable_from_zone_and_port_list().
+ * Walks argv at the SAVE_PORT_ZONE_STRIDE-strided offsets, extracts the
+ * old_ct_zone column (the port_uuid column has already been validated
+ * pre-fork by check_zone_save_args and is otherwise discarded - the
+ * delete path filters strictly on CT zone), and hands the array to
+ * create_hashtable_from_zone_list().
  *
  * Args:
- *   @argv      array of CLI args.
- *   @out_ports output: ports_to_migrate hashtable.
+ *   @argv array of CLI args.
  *
  * Returns:
- *   zones_to_migrate hashtable on success, NULL on failure (in which case
- *   *out_ports is left set to NULL).
+ *   zones_to_migrate hashtable on success, NULL on failure.
  */
 static GHashTable *
-create_zones_and_port_ht_from_args(char *argv[], GHashTable **out_ports)
+create_zones_ht_from_args(char *argv[])
 {
     int n_entries;
     int i;
     const char **zones;
-    const char **port_uuids;
     GHashTable *ht;
 
     ensure_cli_arg_is_int_at_least(argv[NUM_ENTRIES_ARG_INDEX], &n_entries,
                                    "num_entries",
                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
     zones = g_malloc0(sizeof(*zones) * n_entries);
-    port_uuids = g_malloc0(sizeof(*port_uuids) * n_entries);
     for (i = 0; i < n_entries; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * SAVE_PORT_ZONE_STRIDE);
-        port_uuids[i] = argv[base];
         zones[i] = argv[base + 1];
     }
 
-    ht = create_hashtable_from_zone_and_port_list(zones, port_uuids,
-                                                  n_entries, out_ports);
+    ht = create_hashtable_from_zone_list(zones, n_entries);
     g_free(zones);
-    g_free(port_uuids);
 
     if (ht == NULL) {
         LOG(ERROR, "%s: Hashtable creation failed.", __func__);
@@ -735,15 +730,12 @@ dmain(int argc, char *argv[])
             }
             save_targets = save_targets_new_from_ips(ips_to_migrate);
         } else {
-            GHashTable *zones_ht = NULL;
-            GHashTable *ports_ht = NULL;
-            zones_ht = create_zones_and_port_ht_from_args(argv, &ports_ht);
+            GHashTable *zones_ht = create_zones_ht_from_args(argv);
             if (zones_ht == NULL) {
                 rc = EINVAL;
                 goto cleanup;
             }
-            save_targets = save_targets_new_from_zones_and_ports(zones_ht,
-                                                                 ports_ht);
+            save_targets = save_targets_new_from_zones(zones_ht);
         }
 
         ret = start_in_save_mode(save_targets, &stop_flag);

--- a/src/main.c
+++ b/src/main.c
@@ -118,13 +118,13 @@ struct cli_mode_config {
         enum load_input_kind load_kind;
     };
     int num_entries;
-    /* LOAD-port-zone mode only: (old_zone -> new_zone) remap built in
-     * check_zone_load_args() during pre-fork validation, consumed in
-     * dmain() after the double fork. NULL for SAVE mode and for
-     * LOAD-legacy mode. Ownership transfers to load_targets_new_from_remap();
-     * the wrapped bundle is destroyed by load_targets_destroy() at dmain
-     * cleanup time. */
-    GHashTable *zone_remap;
+    /* LOAD-port-zone mode only: (old_zone -> new_zone) src-to-dst zone
+     * map built in check_zone_load_args() during pre-fork validation,
+     * consumed in dmain() after the double fork. NULL for SAVE mode and
+     * for LOAD-legacy mode. Ownership transfers to
+     * create_load_mode_config_for_port_zone_mode(); the wrapped bundle is
+     * destroyed by destroy_load_mode_config() at dmain cleanup time. */
+    GHashTable *src_dst_zone_map;
 };
  
  const char *lmct_config_path = "/etc/lmct_config";
@@ -164,7 +164,7 @@ struct cli_mode_config {
  
     targs = (struct ct_events_targs *) data;
     LOG(INFO, "%s: Starting conntrack events thread. kind=%s is_src=%d",
-        __func__, save_input_kind_to_string(targs->targets->kind),
+        __func__, save_input_kind_to_string(targs->save_config->kind),
         targs->is_src);
 
     nl = mnl_socket_open(NETLINK_NETFILTER);
@@ -184,73 +184,73 @@ struct cli_mode_config {
          return NULL;
      }
  
-    listen_for_conntrack_events(nl, targs->targets,
+    listen_for_conntrack_events(nl, targs->save_config,
                                 targs->is_src, targs->stop_flag);
     mnl_socket_close(nl);
 
     LOG(INFO, "%s: Finished conntrack events thread. kind=%s is_src=%d",
-        __func__, save_input_kind_to_string(targs->targets->kind),
+        __func__, save_input_kind_to_string(targs->save_config->kind),
         targs->is_src);
 
     return NULL;
 }
  
- /**
-  * Gets all the entries present in the kernel CT table for the given
-  * SAVE migration targets.
-  *
-  * Args:
-  *   @targets SAVE targets bundle (mode-aware) used to filter the required
-  *            CT entries.
-  */
- static void
- dump_conntrack(struct save_targets *targets)
- {
-     struct nfct_handle *handle;
+/**
+ * Gets all the entries present in the kernel CT table for the given
+ * SAVE-mode config.
+ *
+ * Args:
+ *   @save_config SAVE-mode config (mode-aware) used to filter the required
+ *                CT entries.
+ */
+static void
+dump_conntrack(struct save_mode_config *save_config)
+{
+    struct nfct_handle *handle;
+
+    // Set the subscriptions for this handle to 0 since we are going to
+    // explicitly request dump on this socket.
+    handle = nfct_open(CONNTRACK, 0);
+    if (handle == NULL) {
+        LOG(ERROR, "%s: nfct_open failed. %s", __func__, strerror(errno));
+        return;
+    }
+    get_conntrack_dump(handle, save_config);
+    nfct_close(handle);
+}
  
-     // Set the subscriptions for this handle to 0 since we are going to
-     // explicitly request dump on this socket.
-     handle = nfct_open(CONNTRACK, 0);
-     if (handle == NULL) {
-         LOG(ERROR, "%s: nfct_open failed. %s", __func__, strerror(errno));
-         return;
-     }
-     get_conntrack_dump(handle, targets);
-     nfct_close(handle);
- }
- 
- /**
-  * Spawn a single ct_events thread with the given is_src flag and
-  * pthread name. On success the thread owns the freshly allocated
-  * struct ct_events_targs and the caller receives it via @out_targs
-  * for later pthread_join + g_free. On failure @*out_targs is left
-  * untouched and the partial allocation is released here.
-  *
-  * Args:
-  *   @targets     SAVE targets bundle threaded down to the events
-  *                callback (read-only over the thread's lifetime).
-  *   @stop_flag   shared stop flag the thread polls for graceful exit.
-  *   @is_src      true for src-filtered BPF (IP mode src thread);
-  *                false for dst-filtered (IP mode dst thread) or for
-  *                the unfiltered zone-mode thread.
-  *   @thread_name pthread_setname_np tag; logged on rename failure.
-  *   @out_targs   output: owning pointer to the thread args bundle.
-  *
-  * Returns:
-  *   0 on success, -1 on pthread_create failure.
-  */
- static int
- create_events_thread(struct save_targets *targets, bool *stop_flag,
-                      bool is_src, const char *thread_name,
-                      struct ct_events_targs **out_targs)
- {
-     struct ct_events_targs *targs;
-     int ret;
- 
-     targs = g_malloc0(sizeof(*targs));
-     targs->targets   = targets;
-     targs->stop_flag = stop_flag;
-     targs->is_src    = is_src;
+/**
+ * Spawn a single ct_events thread with the given is_src flag and
+ * pthread name. On success the thread owns the freshly allocated
+ * struct ct_events_targs and the caller receives it via @out_targs
+ * for later pthread_join + g_free. On failure @*out_targs is left
+ * untouched and the partial allocation is released here.
+ *
+ * Args:
+ *   @save_config SAVE-mode config threaded down to the events
+ *                callback (read-only over the thread's lifetime).
+ *   @stop_flag   shared stop flag the thread polls for graceful exit.
+ *   @is_src      true for src-filtered BPF (IP mode src thread);
+ *                false for dst-filtered (IP mode dst thread) or for
+ *                the unfiltered zone-mode thread.
+ *   @thread_name pthread_setname_np tag; logged on rename failure.
+ *   @out_targs   output: owning pointer to the thread args bundle.
+ *
+ * Returns:
+ *   0 on success, -1 on pthread_create failure.
+ */
+static int
+create_events_thread(struct save_mode_config *save_config, bool *stop_flag,
+                     bool is_src, const char *thread_name,
+                     struct ct_events_targs **out_targs)
+{
+    struct ct_events_targs *targs;
+    int ret;
+
+    targs = g_malloc0(sizeof(*targs));
+    targs->save_config = save_config;
+    targs->stop_flag   = stop_flag;
+    targs->is_src      = is_src;
  
      ret = pthread_create(&targs->tid, NULL, &pthread_wrapper_ct_events, targs);
      if (ret != 0) {
@@ -325,94 +325,94 @@ struct cli_mode_config {
   * The above workflow is used to maintain a local copy of the CT entries for
   * the VM.
   *
-  * Args:
-  *   @targets SAVE targets bundle (mode-aware) for which CT entries have
-  *            to be migrated.
-  *   @stop_flag flag used by thread to exit after dbus operations.
-  *
-  * Returns:
-  *   0 in case of success, -1 otherwise
-  */
- static int
- start_in_save_mode(struct save_targets *targets, bool *stop_flag)
- {
-     struct ct_events_targs *src_targs  = NULL;
-     struct ct_events_targs *dst_targs  = NULL;
-     struct ct_events_targs *zone_targs = NULL;
-     uint32_t num_entries;
- 
-     /* Common: arity + early exits. The "no entries" path is not an
-      * error in either mode (e.g. a VM with no IPv4 NICs in IP mode);
-      * QEMU expects the helper to live for the migration window, so we
-      * just skip starting the worker threads and let the DBus loop run. */
-     if (targets->kind == SAVE_INPUT_IPS) {
-         num_entries = g_hash_table_size(targets->ips_to_migrate);
-     } else {
-         num_entries = g_hash_table_size(targets->zones_to_migrate);
-     }
-     if (num_entries == 0) {
-         LOG(INFO, "%s: No entries to migrate (kind=%s); skipping save "
-             "mode threads", __func__,
-             save_input_kind_to_string(targets->kind));
-         return 0;
-     }
-     /* IP-only: BPF filter cap. Zone mode does in-callback matching so
-      * the per-IP limit does not apply. */
-     if (targets->kind == SAVE_INPUT_IPS &&
-         num_entries > MAX_IP_ADDRESSES_SUPPORTED) {
-         LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
-             "No Conntrack Migration will be performed.",
-             MAX_IP_ADDRESSES_SUPPORTED);
-         return 0;
-     }
- 
-     /* Common: wire up the delete-thread state, then create the thread.
-      * The delete thread is started in BOTH modes; the body of
-      * _delete_ct_entries dispatches on kind when on_clear wakes it up.
-      * NOTE: ct_del_args is an extern global. */
-     ct_del_args.kind = targets->kind;
-     if (targets->kind == SAVE_INPUT_IPS) {
-         ct_del_args.ips_migrated = targets->ips_to_migrate;
-     } else {
-         ct_del_args.zones_migrated = targets->zones_to_migrate;
-     }
-     if (create_delete_thread() != 0) {
-         return -1;
-     }
- 
-     /* Mode-specific: create the events thread(s). IP mode runs two
-      * BPF-filtered threads (src + dst). Zone mode runs one unfiltered
-      * thread; the callback handles zone matching in-process because
-      * BPF cannot filter on CT zone. */
-     if (targets->kind == SAVE_INPUT_IPS) {
-         if (create_events_thread(targets, stop_flag, true,
-                                  "ct_events_src", &src_targs) != 0) {
-             goto cleanup_delete_thread;
-         }
-         if (create_events_thread(targets, stop_flag, false,
-                                  "ct_events_dst", &dst_targs) != 0) {
-             goto cleanup_delete_thread;
-         }
-     } else {
-         if (create_events_thread(targets, stop_flag, false,
-                                  "ct_events_zone", &zone_targs) != 0) {
-             goto cleanup_delete_thread;
-         }
-     }
- 
-     /* Common: dump live entries, then join events thread(s) + delete
-      * thread in that order so on_clear can drive the shutdown. */
-     dump_conntrack(targets);
- 
-     if (targets->kind == SAVE_INPUT_IPS) {
-         pthread_join(src_targs->tid, NULL);
-         pthread_join(dst_targs->tid, NULL);
-         g_free(src_targs);
-         g_free(dst_targs);
-     } else {
-         pthread_join(zone_targs->tid, NULL);
-         g_free(zone_targs);
-     }
+ * Args:
+ *   @save_config SAVE-mode config (mode-aware) for which CT entries have
+ *                to be migrated.
+ *   @stop_flag flag used by thread to exit after dbus operations.
+ *
+ * Returns:
+ *   0 in case of success, -1 otherwise
+ */
+static int
+start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
+{
+    struct ct_events_targs *src_targs  = NULL;
+    struct ct_events_targs *dst_targs  = NULL;
+    struct ct_events_targs *zone_targs = NULL;
+    uint32_t num_entries;
+
+    /* Common: arity + early exits. The "no entries" path is not an
+     * error in either mode (e.g. a VM with no IPv4 NICs in IP mode);
+     * QEMU expects the helper to live for the migration window, so we
+     * just skip starting the worker threads and let the DBus loop run. */
+    if (save_config->kind == SAVE_INPUT_IPS) {
+        num_entries = g_hash_table_size(save_config->ips_to_migrate);
+    } else {
+        num_entries = g_hash_table_size(save_config->zones_to_migrate);
+    }
+    if (num_entries == 0) {
+        LOG(INFO, "%s: No entries to migrate (kind=%s); skipping save "
+            "mode threads", __func__,
+            save_input_kind_to_string(save_config->kind));
+        return 0;
+    }
+    /* IP-only: BPF filter cap. Zone mode does in-callback matching so
+     * the per-IP limit does not apply. */
+    if (save_config->kind == SAVE_INPUT_IPS &&
+        num_entries > MAX_IP_ADDRESSES_SUPPORTED) {
+        LOG(WARNING, "Number of IP addresses exceeds the max limit: %d. "
+            "No Conntrack Migration will be performed.",
+            MAX_IP_ADDRESSES_SUPPORTED);
+        return 0;
+    }
+
+    /* Common: wire up the delete-thread state, then create the thread.
+     * The delete thread is started in BOTH modes; the body of
+     * _delete_ct_entries dispatches on kind when on_clear wakes it up.
+     * NOTE: ct_del_args is an extern global. */
+    ct_del_args.kind = save_config->kind;
+    if (save_config->kind == SAVE_INPUT_IPS) {
+        ct_del_args.ips_migrated = save_config->ips_to_migrate;
+    } else {
+        ct_del_args.zones_migrated = save_config->zones_to_migrate;
+    }
+    if (create_delete_thread() != 0) {
+        return -1;
+    }
+
+    /* Mode-specific: create the events thread(s). IP mode runs two
+     * BPF-filtered threads (src + dst). Zone mode runs one unfiltered
+     * thread; the callback handles zone matching in-process because
+     * BPF cannot filter on CT zone. */
+    if (save_config->kind == SAVE_INPUT_IPS) {
+        if (create_events_thread(save_config, stop_flag, true,
+                                 "ct_events_src", &src_targs) != 0) {
+            goto cleanup_delete_thread;
+        }
+        if (create_events_thread(save_config, stop_flag, false,
+                                 "ct_events_dst", &dst_targs) != 0) {
+            goto cleanup_delete_thread;
+        }
+    } else {
+        if (create_events_thread(save_config, stop_flag, false,
+                                 "ct_events_zone", &zone_targs) != 0) {
+            goto cleanup_delete_thread;
+        }
+    }
+
+    /* Common: dump live entries, then join events thread(s) + delete
+     * thread in that order so on_clear can drive the shutdown. */
+    dump_conntrack(save_config);
+
+    if (save_config->kind == SAVE_INPUT_IPS) {
+        pthread_join(src_targs->tid, NULL);
+        pthread_join(dst_targs->tid, NULL);
+        g_free(src_targs);
+        g_free(dst_targs);
+    } else {
+        pthread_join(zone_targs->tid, NULL);
+        g_free(zone_targs);
+    }
      pthread_join(ct_del_args.tid, NULL);
      return 0;
  
@@ -679,8 +679,8 @@ struct cli_mode_config {
      bool log_open = false;
      bool dbus_started = false;
      bool loop_mu_inited = false;
-     struct dbus_targs dbus_server_args = {0};
-     struct save_targets *save_targets = NULL;
+    struct dbus_targs dbus_server_args = {0};
+    struct save_mode_config *save_config = NULL;
  
      (void) argc;
  
@@ -722,9 +722,9 @@ struct cli_mode_config {
      // Start the dbus server
      dbus_server_args.helper_id    = helper_id;
      dbus_server_args.stop_flag    = &stop_flag;
-     dbus_server_args.mode         = cli->mode;
-     dbus_server_args.load_targets = NULL;
-     dbus_server_args.loop         = NULL;
+    dbus_server_args.mode         = cli->mode;
+    dbus_server_args.load_config  = NULL;
+    dbus_server_args.loop         = NULL;
      dbus_server_args.should_quit  = false;
      ret = pthread_mutex_init(&dbus_server_args.loop_mu, NULL);
      if (ret != 0) {
@@ -734,28 +734,29 @@ struct cli_mode_config {
      }
      loop_mu_inited = true;
  
-    /* In LOAD mode wire the dbus thread to the pre-built (old_zone ->
-     * new_zone) remap so it's ready by the time the destination's Load
-     * IPC arrives. The remap was built and validated pre-fork in
-     * check_zone_load_args() and rides through fork() in cli->zone_remap
-     * via COW of the parent's address space. SAVE mode and LOAD-legacy
-     * mode leave zone_remap NULL. */
-    if (cli->mode == LOAD_MODE) {
-        if (cli->load_kind == LOAD_INPUT_LEGACY) {
-            dbus_server_args.load_targets = load_targets_new_ips();
-            LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
-        } else {
-            dbus_server_args.load_targets =
-                load_targets_new_from_remap(cli->zone_remap);
-            if (dbus_server_args.load_targets == NULL) {
-                LOG(ERROR, "%s: failed to create load_targets", __func__);
-                rc = EINVAL;
-                goto cleanup;
-            }
-            LOG(INFO, "%s: LOAD port-zones mode, %d remap entries",
-                __func__, cli->num_entries);
-        }
-    }
+   /* In LOAD mode wire the dbus thread to the pre-built (old_zone ->
+    * new_zone) src-to-dst zone map so it's ready by the time the
+    * destination's Load IPC arrives. The map was built and validated
+    * pre-fork in check_zone_load_args() and rides through fork() in
+    * cli->src_dst_zone_map via COW of the parent's address space.
+    * SAVE mode and LOAD-legacy mode leave src_dst_zone_map NULL. */
+   if (cli->mode == LOAD_MODE) {
+       if (cli->load_kind == LOAD_INPUT_LEGACY) {
+           dbus_server_args.load_config =
+               create_load_mode_config_for_legacy_mode();
+           LOG(INFO, "%s: LOAD legacy mode (no zone rewrite)", __func__);
+       } else {
+           dbus_server_args.load_config =
+               create_load_mode_config_for_port_zone_mode(cli->src_dst_zone_map);
+           if (dbus_server_args.load_config == NULL) {
+               LOG(ERROR, "%s: failed to create load_config", __func__);
+               rc = EINVAL;
+               goto cleanup;
+           }
+           LOG(INFO, "%s: LOAD port-zones mode, %d src-to-dst zone map entries",
+               __func__, cli->num_entries);
+       }
+   }
  
      ret = pthread_create(&dbus_server_args.tid,
                           NULL, dbus_server_init,
@@ -773,37 +774,37 @@ struct cli_mode_config {
              __func__, strerror(ret));
      }
  
-     // Start save mode threads.
-     if (cli->mode == SAVE_MODE) {
-         if (cli->save_kind == SAVE_INPUT_IPS) {
-             GHashTable *ips_to_migrate;
-             ips_to_migrate = create_ips_ht_from_args(argv, cli->num_entries);
-             if (ips_to_migrate == NULL) {
-                 rc = EINVAL;
-                 goto cleanup;
-             }
-             save_targets = save_targets_new_from_ips(ips_to_migrate);
-         } else {
-             GHashTable *zones_ht =
-                 create_zones_ht_from_args(argv, cli->num_entries);
-             if (zones_ht == NULL) {
-                 rc = EINVAL;
-                 goto cleanup;
-             }
-             save_targets = save_targets_new_from_zones(zones_ht);
-         }
- 
-         ret = start_in_save_mode(save_targets, &stop_flag);
-         if (ret != 0) {
-             rc = EAGAIN;
-             /* start_in_save_mode may have left events threads running
-              * that still reference save_targets (a pre-existing issue
-              * tracked separately). Don't destroy save_targets in that
-              * case -- a small intentional leak on the abnormal-exit
-              * path is preferable to a use-after-free. */
-             save_targets = NULL;
-         }
-     }
+    // Start save mode threads.
+    if (cli->mode == SAVE_MODE) {
+        if (cli->save_kind == SAVE_INPUT_IPS) {
+            GHashTable *ips_to_migrate;
+            ips_to_migrate = create_ips_ht_from_args(argv, cli->num_entries);
+            if (ips_to_migrate == NULL) {
+                rc = EINVAL;
+                goto cleanup;
+            }
+            save_config = create_save_mode_config_for_ip_mode(ips_to_migrate);
+        } else {
+            GHashTable *zones_ht =
+                create_zones_ht_from_args(argv, cli->num_entries);
+            if (zones_ht == NULL) {
+                rc = EINVAL;
+                goto cleanup;
+            }
+            save_config = create_save_mode_config_for_port_zone_mode(zones_ht);
+        }
+
+        ret = start_in_save_mode(save_config, &stop_flag);
+        if (ret != 0) {
+            rc = EAGAIN;
+            /* start_in_save_mode may have left events threads running
+             * that still reference save_config (a pre-existing issue
+             * tracked separately). Don't destroy save_config in that
+             * case -- a small intentional leak on the abnormal-exit
+             * path is preferable to a use-after-free. */
+            save_config = NULL;
+        }
+    }
  
  cleanup:
      /* Tell any still-running events threads to exit. start_in_save_mode
@@ -823,12 +824,12 @@ struct cli_mode_config {
          }
          pthread_join(dbus_server_args.tid, NULL);
      }
-     if (save_targets != NULL) {
-         save_targets_destroy(save_targets);
-     }
-     if (dbus_server_args.load_targets != NULL) {
-         load_targets_destroy(dbus_server_args.load_targets);
-     }
+    if (save_config != NULL) {
+        destroy_save_mode_config(save_config);
+    }
+    if (dbus_server_args.load_config != NULL) {
+        destroy_load_mode_config(dbus_server_args.load_config);
+    }
      if (loop_mu_inited) {
          pthread_mutex_destroy(&dbus_server_args.loop_mu);
      }
@@ -963,16 +964,18 @@ struct cli_mode_config {
  
 /**
  * Per-entry content checks for the new LOAD port-zone layout, folded
- * with the (old_zone -> new_zone) remap build into a single argv pass.
+ * with the (old_zone -> new_zone) src-to-dst zone map build into a
+ * single argv pass.
  *
  * Arity is guaranteed by detect_load_input_kind(); we validate the content
  * of each (port_uuid, old_ct_zone, new_ct_zone) triple and, on success,
- * insert (old_zone -> new_zone) into a freshly allocated remap hashtable.
- * Returning the remap directly (instead of validating now and reparsing
- * post-fork via a separate builder) lets dmain() consume cli->zone_remap
- * without re-walking argv. The port_uuid column is content-checked here
- * but not stored: at LOAD time each CT entry only carries ATTR_ZONE, so
- * the only usable pivot is old_zone -> new_zone.
+ * insert (old_zone -> new_zone) into a freshly allocated hashtable.
+ * Returning the map directly (instead of validating now and reparsing
+ * post-fork via a separate builder) lets dmain() consume
+ * cli->src_dst_zone_map without re-walking argv. The port_uuid column
+ * is content-checked here but not stored: at LOAD time each CT entry
+ * only carries ATTR_ZONE, so the only usable pivot is
+ * old_zone -> new_zone.
  *
  * If two entries declare the same old_zone with different new_zones, the
  * last write wins and a WARNING is logged. Bad input (malformed UUID or
@@ -985,12 +988,13 @@ struct cli_mode_config {
  *
  * Returns:
  *   Newly allocated (old_zone -> new_zone) hashtable. Ownership transfers
- *   to the caller; consumed by load_targets_new_from_remap() in dmain().
+ *   to the caller; consumed by
+ *   create_load_mode_config_for_port_zone_mode() in dmain().
  */
 static GHashTable *
 check_zone_load_args(int argc, const char *const argv[])
 {
-    GHashTable *remap;
+    GHashTable *src_dst_zone_map;
     int n;
     int i;
     const int old_zone_offset = 1;
@@ -1002,7 +1006,7 @@ check_zone_load_args(int argc, const char *const argv[])
                                    "num_entries",
                                    MIN_ACCEPTABLE_VALUE_FOR_NUM_ENTRIES);
 
-    remap = g_hash_table_new(g_direct_hash, g_direct_equal);
+    src_dst_zone_map = g_hash_table_new(g_direct_hash, g_direct_equal);
 
     for (i = 0; i < n; i++) {
         int base = ENTRIES_LIST_START_ARG_INDEX + (i * LOAD_PORT_ZONE_STRIDE);
@@ -1013,25 +1017,25 @@ check_zone_load_args(int argc, const char *const argv[])
         gpointer existing_val;
 
         if (!is_valid_uuid_string(port_uuid)) {
-            g_hash_table_destroy(remap);
+            g_hash_table_destroy(src_dst_zone_map);
             errx(EXIT_FAILURE,
                  "Invalid UUID at port-zone entry %d: '%s'",
                  i, port_uuid);
         }
         if (!parse_ct_zone(old_zone_str, &old_zone)) {
-            g_hash_table_destroy(remap);
+            g_hash_table_destroy(src_dst_zone_map);
             errx(EXIT_FAILURE,
                  "Invalid old_ct_zone at port-zone entry %d: '%s'",
                  i, old_zone_str);
         }
         if (!parse_ct_zone(new_zone_str, &new_zone)) {
-            g_hash_table_destroy(remap);
+            g_hash_table_destroy(src_dst_zone_map);
             errx(EXIT_FAILURE,
                  "Invalid new_ct_zone at port-zone entry %d: '%s'",
                  i, new_zone_str);
         }
 
-        if (g_hash_table_lookup_extended(remap,
+        if (g_hash_table_lookup_extended(src_dst_zone_map,
                                          GUINT_TO_POINTER((guint) old_zone),
                                          NULL, &existing_val)) {
             uint16_t existing = (uint16_t) GPOINTER_TO_UINT(existing_val);
@@ -1043,12 +1047,12 @@ check_zone_load_args(int argc, const char *const argv[])
             }
         }
 
-        g_hash_table_insert(remap,
+        g_hash_table_insert(src_dst_zone_map,
                             GUINT_TO_POINTER((guint) old_zone),
                             GUINT_TO_POINTER((guint) new_zone));
     }
 
-    return remap;
+    return src_dst_zone_map;
 }
  
  /**
@@ -1099,39 +1103,39 @@ check_zone_load_args(int argc, const char *const argv[])
  *
  * Legacy LOAD takes no extra args beyond <mode> <helper_id>; the new LOAD
  * port-zone layout is content-validated AND the (old_zone -> new_zone)
- * remap is built in the same pass via check_zone_load_args(). The built
- * remap is published to the caller so dmain() can wrap it post-fork
- * without re-walking argv.
+ * src-to-dst zone map is built in the same pass via check_zone_load_args().
+ * The built map is published to the caller so dmain() can wrap it
+ * post-fork without re-walking argv.
  *
  * Reports the detected sub-kind and the declared entry count to the
  * caller so they can be recorded on cli_mode_config without an extra
  * argv parse.
  *
  * Args:
- *   @argc            num of arguments.
- *   @argv            array of CLI arguments.
- *   @out_kind        output pointer for the detected sub-kind. May be NULL.
- *   @out_n_entries   output pointer for the declared entry count, captured
- *                    from detect_load_input_kind's existing parse. May be
- *                    NULL. 0 on the LOAD legacy shortcut.
- *   @out_zone_remap  output pointer for the freshly built remap. May be
- *                    NULL (caller doesn't care). Always set to NULL for
- *                    LOAD_INPUT_LEGACY; non-NULL for LOAD_INPUT_PORT_ZONES.
- *                    Ownership transfers to the caller.
+ *   @argc                num of arguments.
+ *   @argv                array of CLI arguments.
+ *   @out_kind            output pointer for the detected sub-kind. May be NULL.
+ *   @out_n_entries       output pointer for the declared entry count, captured
+ *                        from detect_load_input_kind's existing parse. May be
+ *                        NULL. 0 on the LOAD legacy shortcut.
+ *   @out_src_dst_zone_map output pointer for the freshly built src-to-dst
+ *                        zone map. May be NULL (caller doesn't care). Always
+ *                        set to NULL for LOAD_INPUT_LEGACY; non-NULL for
+ *                        LOAD_INPUT_PORT_ZONES. Ownership transfers to the caller.
  */
 static void
 check_load_mode_args(int argc, const char *const argv[],
                      enum load_input_kind *out_kind,
                      int *out_n_entries,
-                     GHashTable **out_zone_remap)
+                     GHashTable **out_src_dst_zone_map)
 {
     int n_entries = 0;
-    GHashTable *remap = NULL;
+    GHashTable *src_dst_zone_map = NULL;
     enum load_input_kind kind =
         detect_load_input_kind(argc, argv, &n_entries);
 
     if (kind == LOAD_INPUT_PORT_ZONES) {
-        remap = check_zone_load_args(argc, argv);
+        src_dst_zone_map = check_zone_load_args(argc, argv);
     } else {
         if (kind != LOAD_INPUT_LEGACY) {
             errx(EXIT_FAILURE, "Invalid load input kind: %d", kind);
@@ -1144,11 +1148,11 @@ check_load_mode_args(int argc, const char *const argv[],
     if (out_n_entries != NULL) {
         *out_n_entries = n_entries;
     }
-    if (out_zone_remap != NULL) {
-        *out_zone_remap = remap;
-    } else if (remap != NULL) {
+    if (out_src_dst_zone_map != NULL) {
+        *out_src_dst_zone_map = src_dst_zone_map;
+    } else if (src_dst_zone_map != NULL) {
         /* Caller dropped ownership; don't leak. */
-        g_hash_table_destroy(remap);
+        g_hash_table_destroy(src_dst_zone_map);
     }
 }
  
@@ -1200,7 +1204,7 @@ check_load_mode_args(int argc, const char *const argv[],
                               &out->num_entries);
     } else {
         check_load_mode_args(argc, argv, &out->load_kind,
-                             &out->num_entries, &out->zone_remap);
+                             &out->num_entries, &out->src_dst_zone_map);
     }
 }
  

--- a/src/main.c
+++ b/src/main.c
@@ -719,13 +719,14 @@ start_in_save_mode(struct save_mode_config *save_config, bool *stop_flag)
          goto cleanup;
      }
  
-     // Start the dbus server
-     dbus_server_args.helper_id    = helper_id;
-     dbus_server_args.stop_flag    = &stop_flag;
+    // Start the dbus server
+    dbus_server_args.helper_id    = helper_id;
+    dbus_server_args.stop_flag    = &stop_flag;
     dbus_server_args.mode         = cli->mode;
+    dbus_server_args.save_kind    = cli->save_kind; /* unused in LOAD; on_save reads it */
     dbus_server_args.load_config  = NULL;
     dbus_server_args.loop         = NULL;
-     dbus_server_args.should_quit  = false;
+    dbus_server_args.should_quit  = false;
      ret = pthread_mutex_init(&dbus_server_args.loop_mu, NULL);
      if (ret != 0) {
          LOG(ERROR, "%s: failed to init loop_mu: %s", __func__, strerror(ret));

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -67,7 +67,7 @@ END_TEST
 START_TEST(test_create_hashtable_from_ip_list_negative_int)
 {
     const char *ip_list[] = { "-1" };
-    GHashTable *ht = create_hashtable_from_ip_list(ip_list, 3);
+    GHashTable *ht = create_hashtable_from_ip_list(ip_list, 1);
 
     ck_assert(ht == NULL);
 }
@@ -97,6 +97,276 @@ START_TEST(test_create_hashtable_from_ip_list_with_ipv6)
 }
 END_TEST
 
+START_TEST(test_create_hashtable_from_ip_list_null_list_positive_count)
+{
+    GHashTable *ht = create_hashtable_from_ip_list(NULL, 3);
+
+    ck_assert(ht == NULL);
+}
+END_TEST
+
+START_TEST(test_convert_save_mode_op_type_to_string)
+{
+    const char *ips_str = convert_save_mode_op_type_to_string(SAVE_IPS_OP);
+    const char *zone_str =
+        convert_save_mode_op_type_to_string(SAVE_PORT_ZONE_OP);
+
+    ck_assert_str_eq(ips_str, "IPS");
+    ck_assert_str_eq(zone_str, "PORT_ZONE");
+}
+END_TEST
+
+START_TEST(test_is_valid_uuid_string_valid)
+{
+    bool ok = is_valid_uuid_string(
+        "port_12345678-1234-1234-1234-123456789abc");
+
+    ck_assert(ok);
+}
+END_TEST
+
+START_TEST(test_is_valid_uuid_string_null)
+{
+    bool ok = is_valid_uuid_string(NULL);
+
+    ck_assert(!ok);
+}
+END_TEST
+
+START_TEST(test_is_valid_uuid_string_missing_prefix)
+{
+    /* A bare canonical UUID is rejected: the "port_" prefix is required. */
+    bool ok = is_valid_uuid_string("12345678-1234-1234-1234-123456789abc");
+
+    ck_assert(!ok);
+}
+END_TEST
+
+START_TEST(test_parse_ct_zone_valid)
+{
+    uint16_t out = 99;
+    bool ok;
+
+    ok = parse_ct_zone("0", &out);
+    ck_assert(ok);
+    ck_assert_int_eq(out, 0);
+
+    ok = parse_ct_zone("1234", &out);
+    ck_assert(ok);
+    ck_assert_int_eq(out, 1234);
+
+    ok = parse_ct_zone("65535", &out);   /* UINT16_MAX boundary */
+    ck_assert(ok);
+    ck_assert_int_eq(out, 65535);
+}
+END_TEST
+
+START_TEST(test_parse_ct_zone_overflow)
+{
+    uint16_t out = 7;
+    bool ok;
+
+    ok = parse_ct_zone("65536", &out);                 /* > UINT16_MAX */
+    ck_assert(!ok);
+
+    ok = parse_ct_zone("99999999999999999999", &out);  /* ERANGE */
+    ck_assert(!ok);
+
+    ck_assert_int_eq(out, 7);                           /* untouched on fail */
+}
+END_TEST
+
+START_TEST(test_parse_ct_zone_trailing_junk)
+{
+    uint16_t out = 7;
+    bool ok;
+
+    ok = parse_ct_zone("10abc", &out);
+    ck_assert(!ok);
+
+    ok = parse_ct_zone("0x10", &out);   /* base 10: stops at 'x' */
+    ck_assert(!ok);
+}
+END_TEST
+
+START_TEST(test_ensure_cli_arg_valid)
+{
+    int out = -1;
+    ensure_cli_arg_is_int_at_least("5", &out, "mode", 1);
+    ck_assert_int_eq(out, 5);
+}
+END_TEST
+
+START_TEST(test_ensure_cli_arg_null_exits)
+{
+    int out = 0;
+    /* errx() -> exit(1), asserted via tcase_add_exit_test(). */
+    ensure_cli_arg_is_int_at_least(NULL, &out, "mode", 1);
+}
+END_TEST
+
+START_TEST(test_ensure_cli_arg_non_numeric_exits)
+{
+    int out = 0;
+    /* errx() -> exit(1), asserted via tcase_add_exit_test(). */
+    ensure_cli_arg_is_int_at_least("abc", &out, "mode", 1);
+}
+END_TEST
+
+START_TEST(test_ensure_cli_arg_below_min_exits)
+{
+    int out = 0;
+    /* errx() -> exit(1), asserted via tcase_add_exit_test(). */
+    ensure_cli_arg_is_int_at_least("0", &out, "mode", 1);
+}
+END_TEST
+
+START_TEST(test_create_hashtable_from_zone_list_valid)
+{
+    const char *zones[] = { "10", "20", "30" };
+    GHashTable *ht = create_hashtable_from_zone_list(zones, 3);
+
+    ck_assert(ht != NULL);
+    ck_assert_int_eq(g_hash_table_size(ht), 3);
+    ck_assert(g_hash_table_contains(ht, GUINT_TO_POINTER(10)));
+    ck_assert(g_hash_table_contains(ht, GUINT_TO_POINTER(20)));
+    ck_assert(g_hash_table_contains(ht, GUINT_TO_POINTER(30)));
+}
+END_TEST
+
+START_TEST(test_create_hashtable_from_zone_list_empty)
+{
+    GHashTable *ht = create_hashtable_from_zone_list(NULL, 0);
+
+    ck_assert(ht != NULL);
+    ck_assert_int_eq(g_hash_table_size(ht), 0);
+}
+END_TEST
+
+START_TEST(test_create_hashtable_from_zone_list_invalid_zone)
+{
+    const char *zones[] = { "10", "abc", "30" };
+    GHashTable *ht = create_hashtable_from_zone_list(zones, 3);
+
+    ck_assert(ht == NULL);
+}
+END_TEST
+
+START_TEST(test_create_hashtable_from_port_zone_pairs_valid)
+{
+    const char *strv[] = {
+        "port_12345678-1234-1234-1234-123456789abc", "10",
+        "port_87654321-4321-4321-4321-cba987654321", "20"
+    };
+    GHashTable *ht = create_hashtable_from_port_zone_pairs(strv, 4);
+
+    ck_assert(ht != NULL);
+    ck_assert_int_eq(g_hash_table_size(ht), 2);
+    ck_assert(g_hash_table_contains(ht, GUINT_TO_POINTER(10)));
+    ck_assert(g_hash_table_contains(ht, GUINT_TO_POINTER(20)));
+}
+END_TEST
+
+START_TEST(test_create_hashtable_from_port_zone_pairs_odd_count)
+{
+    const char *strv[] = {
+        "port_12345678-1234-1234-1234-123456789abc", "10",
+        "port_87654321-4321-4321-4321-cba987654321"
+    };
+    GHashTable *ht = create_hashtable_from_port_zone_pairs(strv, 3);
+
+    ck_assert(ht == NULL);
+}
+END_TEST
+
+START_TEST(test_create_hashtable_from_port_zone_pairs_bad_uuid)
+{
+    const char *strv[] = { "not_a_port_uuid", "10" };
+    GHashTable *ht = create_hashtable_from_port_zone_pairs(strv, 2);
+
+    ck_assert(ht == NULL);
+}
+END_TEST
+
+START_TEST(test_create_save_mode_config_for_ip_mode)
+{
+    GHashTable *ips = g_hash_table_new(g_direct_hash, g_direct_equal);
+    struct save_mode_config *cfg = create_save_mode_config_for_ip_mode(ips);
+
+    ck_assert(cfg != NULL);
+    ck_assert_int_eq(cfg->op_type, SAVE_IPS_OP);
+    ck_assert(cfg->ips_to_migrate == ips);
+
+    destroy_save_mode_config(cfg);
+}
+END_TEST
+
+START_TEST(test_create_save_mode_config_for_port_zone_mode)
+{
+    GHashTable *zones = g_hash_table_new(g_direct_hash, g_direct_equal);
+    struct save_mode_config *cfg =
+        create_save_mode_config_for_port_zone_mode(zones);
+
+    ck_assert(cfg != NULL);
+    ck_assert_int_eq(cfg->op_type, SAVE_PORT_ZONE_OP);
+    ck_assert(cfg->zones_to_migrate == zones);
+
+    destroy_save_mode_config(cfg);
+}
+END_TEST
+
+START_TEST(test_create_save_mode_config_for_ip_mode_null_exits)
+{
+    /* errx() -> exit(1), asserted via tcase_add_exit_test(). */
+    create_save_mode_config_for_ip_mode(NULL);
+}
+END_TEST
+
+START_TEST(test_destroy_save_mode_config_null)
+{
+    destroy_save_mode_config(NULL);   /* NULL-tolerant: must not crash */
+}
+END_TEST
+
+START_TEST(test_create_load_mode_config_for_legacy_mode)
+{
+    struct load_mode_config *cfg = create_load_mode_config_for_legacy_mode();
+
+    ck_assert(cfg != NULL);
+    ck_assert_int_eq(cfg->op_type, LOAD_IPS_OP);
+    ck_assert(cfg->src_dst_zone_map == NULL);
+
+    destroy_load_mode_config(cfg);
+}
+END_TEST
+
+START_TEST(test_create_load_mode_config_for_port_zone_mode)
+{
+    GHashTable *map = g_hash_table_new(g_direct_hash, g_direct_equal);
+    struct load_mode_config *cfg =
+        create_load_mode_config_for_port_zone_mode(map);
+
+    ck_assert(cfg != NULL);
+    ck_assert_int_eq(cfg->op_type, LOAD_PORT_ZONE_OP);
+    ck_assert(cfg->src_dst_zone_map == map);
+
+    destroy_load_mode_config(cfg);
+}
+END_TEST
+
+START_TEST(test_create_load_mode_config_for_port_zone_mode_null_exits)
+{
+    /* errx() -> exit(1), asserted via tcase_add_exit_test(). */
+    create_load_mode_config_for_port_zone_mode(NULL);
+}
+END_TEST
+
+START_TEST(test_destroy_load_mode_config_null)
+{
+    destroy_load_mode_config(NULL);   /* NULL-tolerant: must not crash */
+}
+END_TEST
+
 Suite *common_suite(void)
 {
     Suite *s;
@@ -107,12 +377,59 @@ Suite *common_suite(void)
     /* Core test case */
     tc_core = tcase_create("Core");
 
+    /* create_hashtable_from_ip_list */
     tcase_add_test(tc_core, test_create_hashtable_from_ip_list);
     tcase_add_test(tc_core, test_create_hashtable_from_ip_list_empty);
     tcase_add_test(tc_core, test_create_hashtable_from_ip_list_one_invalid);
     tcase_add_test(tc_core, test_create_hashtable_from_ip_list_all_invalid);
     tcase_add_test(tc_core, test_create_hashtable_from_ip_list_negative_int);
     tcase_add_test(tc_core, test_create_hashtable_from_ip_list_with_ipv6);
+    tcase_add_test(tc_core,
+                   test_create_hashtable_from_ip_list_null_list_positive_count);
+
+    /* convert_save_mode_op_type_to_string */
+    tcase_add_test(tc_core, test_convert_save_mode_op_type_to_string);
+
+    /* is_valid_uuid_string */
+    tcase_add_test(tc_core, test_is_valid_uuid_string_valid);
+    tcase_add_test(tc_core, test_is_valid_uuid_string_null);
+    tcase_add_test(tc_core, test_is_valid_uuid_string_missing_prefix);
+
+    /* parse_ct_zone */
+    tcase_add_test(tc_core, test_parse_ct_zone_valid);
+    tcase_add_test(tc_core, test_parse_ct_zone_overflow);
+    tcase_add_test(tc_core, test_parse_ct_zone_trailing_junk);
+
+    /* ensure_cli_arg_is_int_at_least */
+    tcase_add_test(tc_core, test_ensure_cli_arg_valid);
+    tcase_add_exit_test(tc_core, test_ensure_cli_arg_null_exits, 1);
+    tcase_add_exit_test(tc_core, test_ensure_cli_arg_non_numeric_exits, 1);
+    tcase_add_exit_test(tc_core, test_ensure_cli_arg_below_min_exits, 1);
+
+    /* create_hashtable_from_zone_list */
+    tcase_add_test(tc_core, test_create_hashtable_from_zone_list_valid);
+    tcase_add_test(tc_core, test_create_hashtable_from_zone_list_empty);
+    tcase_add_test(tc_core, test_create_hashtable_from_zone_list_invalid_zone);
+
+    /* create_hashtable_from_port_zone_pairs */
+    tcase_add_test(tc_core, test_create_hashtable_from_port_zone_pairs_valid);
+    tcase_add_test(tc_core,
+                   test_create_hashtable_from_port_zone_pairs_odd_count);
+    tcase_add_test(tc_core, test_create_hashtable_from_port_zone_pairs_bad_uuid);
+
+    /* save_mode_config lifecycle */
+    tcase_add_test(tc_core, test_create_save_mode_config_for_ip_mode);
+    tcase_add_test(tc_core, test_create_save_mode_config_for_port_zone_mode);
+    tcase_add_exit_test(tc_core,
+                        test_create_save_mode_config_for_ip_mode_null_exits, 1);
+    tcase_add_test(tc_core, test_destroy_save_mode_config_null);
+
+    /* load_mode_config lifecycle */
+    tcase_add_test(tc_core, test_create_load_mode_config_for_legacy_mode);
+    tcase_add_test(tc_core, test_create_load_mode_config_for_port_zone_mode);
+    tcase_add_exit_test(tc_core,
+                  test_create_load_mode_config_for_port_zone_mode_null_exits, 1);
+    tcase_add_test(tc_core, test_destroy_load_mode_config_null);
 
     suite_add_tcase(s, tc_core);
 

--- a/tests/test_conntrack.c
+++ b/tests/test_conntrack.c
@@ -55,8 +55,9 @@ gboolean cmp_ct(gpointer key, gpointer value, gpointer user_data) {
 
 void
 update_conntrack_store(struct conntrack_store *conn_store,
-                       struct nf_conntrack *ct,
-                       enum nf_conntrack_msg_type type)
+                       const struct nf_conntrack *ct,
+                       enum nf_conntrack_msg_type type,
+                       enum save_mode_op_type op_type)
 {
     // For the purpose of testing we are using ct mark as id. because
     // ct_id is not known while programming so validation becomes easier.
@@ -89,11 +90,17 @@ update_conntrack_store(struct conntrack_store *conn_store,
         break;
     }
 }
+
+const char *
+convert_save_mode_op_type_to_string(enum save_mode_op_type op_type)
+{
+    return op_type == SAVE_IPS_OP ? "ips" : "port_zone";
+}
 //=========================End of dependencies=================================
 
 //=========================Start of HELPER Functions =========================
 GHashTable *
-ht_from_ip_list(const char *ip_list[], int num_ips)
+ht_from_ip_list(const char *const ip_list[], int num_ips)
 {
     int i;
     GHashTable *ht;
@@ -102,6 +109,19 @@ ht_from_ip_list(const char *ip_list[], int num_ips)
         struct in_addr ip;
         inet_aton(ip_list[i], &ip);
         g_hash_table_insert(ht, GUINT_TO_POINTER(ip.s_addr),
+                            GINT_TO_POINTER(1));
+    }
+    return ht;
+}
+
+GHashTable *
+ht_from_zone_list(const uint16_t zones[], int num_zones)
+{
+    int i;
+    GHashTable *ht;
+    ht = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
+    for (i = 0; i < num_zones; i++) {
+        g_hash_table_insert(ht, GUINT_TO_POINTER((guint) zones[i]),
                             GINT_TO_POINTER(1));
     }
     return ht;
@@ -308,10 +328,14 @@ START_TEST(test_conntrack_dump)
     ck_assert(h != NULL);
 
     const char *ips[] = { "1.1.1.1", "2.2.2.2" };
-    GHashTable *ips_to_migrate = ht_from_ip_list(ips, 5);
+    GHashTable *ips_to_migrate = ht_from_ip_list(ips, 2);
     ck_assert(ips_to_migrate != NULL);
 
-    ret = get_conntrack_dump(h, ips_to_migrate);
+    struct save_mode_config save_config = {
+        .op_type = SAVE_IPS_OP,
+        .ips_to_migrate = ips_to_migrate
+    };
+    ret = get_conntrack_dump(h, &save_config);
 
     ck_assert(ret == 0);
     ck_assert(g_hash_table_size(conn_store->store) == 4);
@@ -323,6 +347,79 @@ START_TEST(test_conntrack_dump)
         verify_ct(ct, exp[i]);
     }
 
+}
+END_TEST
+
+START_TEST(test_conntrack_dump_for_zone)
+{
+    conn_store = create_conntrack_store();
+    int num = 6;
+
+    // Zones 10 and 20 are migrated; zone 99 is not, so it must be ignored.
+    // Only ATTR_ZONE is read by the zone filter (ct_get_migration_zone).
+    struct nf_conntrack *zone_entry1 = ct_new(
+        "1.1.1.1", "2.2.2.2", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 1);
+    nfct_set_attr_u16(zone_entry1, ATTR_ZONE, 10);
+    struct nf_conntrack *zone_entry2 = ct_new(
+        "1.1.1.1", "2.2.2.2", 1029, 9091, TCP_CONNTRACK_SYN_SENT, 1000, 2);
+    nfct_set_attr_u16(zone_entry2, ATTR_ZONE, 10);
+    struct nf_conntrack *zone_entry3 = ct_new(
+        "3.3.3.3", "4.4.4.4", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 3);
+    nfct_set_attr_u16(zone_entry3, ATTR_ZONE, 20);
+    struct nf_conntrack *zone_entry4 = ct_new(
+        "5.5.5.5", "6.6.6.6", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 4);
+    nfct_set_attr_u16(zone_entry4, ATTR_ZONE, 99);
+
+    struct nf_conntrack *ct_list[6] = {
+        zone_entry1,
+        zone_entry2,
+        zone_entry3,
+        zone_entry4,
+        // zone-less entry -> rejected by validate_ct_entry in zone mode.
+        ct_new("7.7.7.7", "8.8.8.8", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 5),
+        ct_new_ipv6("::1", "fe80::1ff:fe23:4567:890a", 1024, 9090,
+                    TCP_CONNTRACK_ESTABLISHED, 1000, 6)
+    };
+    struct nf_conntrack *exp[3] = {
+        ct_new("1.1.1.1", "2.2.2.2", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 1),
+        ct_new("1.1.1.1", "2.2.2.2", 1029, 9091,
+               TCP_CONNTRACK_SYN_SENT, 1000, 2),
+        ct_new("3.3.3.3", "4.4.4.4", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 3),
+    };
+
+    int ret = flush_conntrack_for_test();
+    ck_assert(ret == 0);
+
+    ret = conntrack_op_for_test(ct_list, num, NFCT_Q_CREATE);
+    ck_assert(ret == 0);
+
+    struct nfct_handle *h = nfct_open(CONNTRACK, 0);
+    ck_assert(h != NULL);
+
+    const uint16_t zones[] = { 10, 20 };
+    GHashTable *zones_to_migrate = ht_from_zone_list(zones, 2);
+    ck_assert(zones_to_migrate != NULL);
+
+    struct save_mode_config save_config = {
+        .op_type = SAVE_PORT_ZONE_OP,
+        .zones_to_migrate = zones_to_migrate
+    };
+    ret = get_conntrack_dump(h, &save_config);
+
+    ck_assert(ret == 0);
+    ck_assert(g_hash_table_size(conn_store->store) == 3);
+
+    uint16_t exp_zone[3] = { 10, 10, 20 };
+    int i;
+    for (i = 0; i < 3; i++) {
+        struct nf_conntrack *ct;
+        ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(i+1));
+        verify_ct(ct, exp[i]);
+        ck_assert(nfct_get_attr_u16(ct, ATTR_ZONE) == exp_zone[i]);
+    }
 }
 END_TEST
 
@@ -464,6 +561,7 @@ START_TEST(test_delete_conntrack)
     ck_assert(ips_on_host != NULL);
 
     struct ct_delete_args args  = {
+        .op_type = SAVE_IPS_OP,
         .ips_migrated = ips_migrated,
         .ips_on_host = ips_on_host,
         .clear_called = true,
@@ -484,7 +582,11 @@ START_TEST(test_delete_conntrack)
                             "4.4.4.4", "5.5.5.5", "7.7.7.7" };
     GHashTable *ips_to_migrate = ht_from_ip_list(_ips_to_mig, 6);
 
-    ret = get_conntrack_dump(h, ips_to_migrate);
+    struct save_mode_config save_config = {
+        .op_type = SAVE_IPS_OP,
+        .ips_to_migrate = ips_to_migrate
+    };
+    ret = get_conntrack_dump(h, &save_config);
     ck_assert(ret == 0);
     ck_assert(g_hash_table_size(conn_store->store) == 2);
 
@@ -494,6 +596,95 @@ START_TEST(test_delete_conntrack)
 
     ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(5));
     verify_ct(ct, exp[1]);
+}
+END_TEST
+
+START_TEST(test_delete_conntrack_for_zone)
+{
+    conn_store = create_conntrack_store();
+    int num = 5;
+
+    // Zones 10 and 20 are migrated; zone 20 is still owned by a port on
+    // this host, so its entries must be preserved. Zone 99 and the
+    // zone-less entry are untouched by the zone-mode delete.
+    struct nf_conntrack *zone_entry1 = ct_new(
+        "1.1.1.1", "2.2.2.2", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 1);
+    nfct_set_attr_u16(zone_entry1, ATTR_ZONE, 10);
+    struct nf_conntrack *zone_entry2 = ct_new(
+        "1.1.1.1", "2.2.2.2", 1029, 9091, TCP_CONNTRACK_SYN_SENT, 1000, 2);
+    nfct_set_attr_u16(zone_entry2, ATTR_ZONE, 10);
+    struct nf_conntrack *zone_entry3 = ct_new(
+        "3.3.3.3", "4.4.4.4", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 3);
+    nfct_set_attr_u16(zone_entry3, ATTR_ZONE, 20);
+    struct nf_conntrack *zone_entry4 = ct_new(
+        "5.5.5.5", "6.6.6.6", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 4);
+    nfct_set_attr_u16(zone_entry4, ATTR_ZONE, 99);
+
+    struct nf_conntrack *ct_list[5] = {
+        zone_entry1,
+        zone_entry2,
+        zone_entry3,
+        zone_entry4,
+        ct_new("7.7.7.7", "8.8.8.8", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 5)
+    };
+
+    int ret = flush_conntrack_for_test();
+    ck_assert(ret == 0);
+
+    ret = conntrack_op_for_test(ct_list, num, NFCT_Q_CREATE);
+    ck_assert(ret == 0);
+
+    struct nfct_handle *h = nfct_open(CONNTRACK, 0);
+    ck_assert(h != NULL);
+
+    // Now migrate zones 10 and 20; zone 20 is still on the host.
+    const uint16_t migrated[] = { 10, 20 };
+    GHashTable *zones_migrated = ht_from_zone_list(migrated, 2);
+    const uint16_t on_host[] = { 20 };
+    GHashTable *zones_on_host = ht_from_zone_list(on_host, 1);
+
+    ck_assert(zones_migrated != NULL);
+    ck_assert(zones_on_host != NULL);
+
+    struct ct_delete_args args = {
+        .op_type = SAVE_PORT_ZONE_OP,
+        .zones_migrated = zones_migrated,
+        .zones_on_host = zones_on_host,
+        .clear_called = true,
+        .mutex = PTHREAD_MUTEX_INITIALIZER,
+        .clear_called_cond = PTHREAD_COND_INITIALIZER
+    };
+
+    delete_ct_entries(&args);
+
+    // Only the zone-10 entries (mark 1, 2) should be gone. Dump back zones
+    // {10, 20, 99}: zone 10 is included so a failed delete would show up.
+    struct nf_conntrack *exp[2] = {
+        ct_new("3.3.3.3", "4.4.4.4", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 3),
+        ct_new("5.5.5.5", "6.6.6.6", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 4)
+    };
+    const uint16_t verify_zones[] = { 10, 20, 99 };
+    GHashTable *zones_to_migrate = ht_from_zone_list(verify_zones, 3);
+
+    struct save_mode_config save_config = {
+        .op_type = SAVE_PORT_ZONE_OP,
+        .zones_to_migrate = zones_to_migrate
+    };
+    ret = get_conntrack_dump(h, &save_config);
+    ck_assert(ret == 0);
+    ck_assert(g_hash_table_size(conn_store->store) == 2);
+
+    struct nf_conntrack *ct;
+    ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(3));
+    verify_ct(ct, exp[0]);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_ZONE) == 20);
+
+    ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(4));
+    verify_ct(ct, exp[1]);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_ZONE) == 99);
 }
 END_TEST
 
@@ -512,7 +703,7 @@ pthread_wrapper_ct_events(void *data)
                         NF_NETLINK_CONNTRACK_DESTROY,
                         MNL_SOCKET_AUTOPID);
     ck_assert(ret >=0);
-    listen_for_conntrack_events(nl, targs->ips_to_migrate,
+    listen_for_conntrack_events(nl, targs->save_config,
                                 targs->is_src, targs->stop_flag);
     mnl_socket_close(nl);
 
@@ -560,8 +751,12 @@ START_TEST(test_conntrack_events_for_src)
     ck_assert(ips_to_migrate != NULL);
 
     stop_flag = false;
+    struct save_mode_config save_config = {
+        .op_type = SAVE_IPS_OP,
+        .ips_to_migrate = ips_to_migrate
+    };
     struct ct_events_targs args;
-    args.ips_to_migrate = ips_to_migrate;
+    args.save_config = &save_config;
     args.stop_flag = &stop_flag;
     args.is_src = true;
 
@@ -667,8 +862,12 @@ START_TEST(test_conntrack_events_for_dst)
     ck_assert(ips_to_migrate != NULL);
 
     stop_flag = false;
+    struct save_mode_config save_config = {
+        .op_type = SAVE_IPS_OP,
+        .ips_to_migrate = ips_to_migrate
+    };
     struct ct_events_targs args;
-    args.ips_to_migrate = ips_to_migrate;
+    args.save_config = &save_config;
     args.stop_flag = &stop_flag;
     args.is_src = false;
 
@@ -733,6 +932,121 @@ START_TEST(test_conntrack_events_for_dst)
 }
 END_TEST
 
+START_TEST(test_conntrack_events_for_zone)
+{
+    conn_store = create_conntrack_store();
+    int num = 5;
+
+    // Zones 10 and 20 are migrated; zone 99 and the zone-less entry must
+    // be ignored by the in-callback zone match.
+    struct nf_conntrack *zone_entry1 = ct_new(
+        "1.1.1.1", "2.2.2.2", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 1);
+    nfct_set_attr_u16(zone_entry1, ATTR_ZONE, 10);
+    struct nf_conntrack *zone_entry2 = ct_new(
+        "1.1.1.1", "2.2.2.2", 1029, 9091, TCP_CONNTRACK_SYN_SENT, 1000, 2);
+    nfct_set_attr_u16(zone_entry2, ATTR_ZONE, 10);
+    struct nf_conntrack *zone_entry3 = ct_new(
+        "3.3.3.3", "4.4.4.4", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 3);
+    nfct_set_attr_u16(zone_entry3, ATTR_ZONE, 20);
+    struct nf_conntrack *zone_entry4 = ct_new(
+        "5.5.5.5", "6.6.6.6", 1024, 9090, TCP_CONNTRACK_ESTABLISHED, 1000, 4);
+    nfct_set_attr_u16(zone_entry4, ATTR_ZONE, 99);
+
+    struct nf_conntrack *ct_list[5] = {
+        zone_entry1,
+        zone_entry2,
+        zone_entry3,
+        zone_entry4,
+        // zone-less entry -> rejected by validate_ct_entry in zone mode.
+        ct_new("7.7.7.7", "8.8.8.8", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 5)
+    };
+
+    int ret = flush_conntrack_for_test();
+    ck_assert(ret == 0);
+
+    const uint16_t zones[] = { 10, 20 };
+    GHashTable *zones_to_migrate = ht_from_zone_list(zones, 2);
+    ck_assert(zones_to_migrate != NULL);
+
+    // is_src is ignored in zone mode (no BPF filter; the callback matches
+    // on CT zone regardless of direction), so a single test suffices.
+    stop_flag = false;
+    struct save_mode_config save_config = {
+        .op_type = SAVE_PORT_ZONE_OP,
+        .zones_to_migrate = zones_to_migrate
+    };
+    struct ct_events_targs args;
+    args.save_config = &save_config;
+    args.stop_flag = &stop_flag;
+    args.is_src = true;
+
+    ret = pthread_create(&args.tid, NULL, &pthread_wrapper_ct_events, &args);
+    ck_assert(ret == 0);
+    sleep(1);
+
+    // create 5 CTs
+    ret = conntrack_op_for_test(ct_list, num, NFCT_Q_CREATE);
+    ck_assert(ret == 0);
+    sleep(1);
+
+    // verify that we should have received events for 3 entries
+    struct nf_conntrack *exp[3] = {
+        ct_new("1.1.1.1", "2.2.2.2", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 1),
+        ct_new("1.1.1.1", "2.2.2.2", 1029, 9091,
+               TCP_CONNTRACK_SYN_SENT, 1000, 2),
+        ct_new("3.3.3.3", "4.4.4.4", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 3),
+    };
+    ck_assert(g_hash_table_size(conn_store->store) == 3);
+    uint16_t exp_zone[3] = { 10, 10, 20 };
+    int i;
+    for (i = 0; i < 3; i++) {
+        struct nf_conntrack *ct;
+        ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(i+1));
+        verify_ct(ct, exp[i]);
+        ck_assert(nfct_get_attr_u16(ct, ATTR_ZONE) == exp_zone[i]);
+    }
+
+    // Now send update to the 2nd entry. syn_sent -> established. Zone must
+    // stay 10 so the kernel matches the existing entry in that zone.
+    struct nf_conntrack *upd[1] = {
+        ct_new("1.1.1.1", "2.2.2.2", 1029, 9091,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 2)
+    };
+    nfct_set_attr_u16(upd[0], ATTR_ZONE, 10);
+    ret = conntrack_op_for_test(upd, 1, NFCT_Q_UPDATE);
+    ck_assert(ret == 0);
+    sleep(1);
+
+    // verify that the entry is updated in our local store as well
+    ck_assert(g_hash_table_size(conn_store->store) == 3);
+    struct nf_conntrack *ct;
+    ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(2));
+    verify_ct(ct, upd[0]);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_ZONE) == 10);
+
+    // Finally delete 1 entries
+    struct nf_conntrack *delete[1] = {
+        ct_new("3.3.3.3", "4.4.4.4", 1024, 9090,
+               TCP_CONNTRACK_ESTABLISHED, 1000, 3)
+    };
+    nfct_set_attr_u16(delete[0], ATTR_ZONE, 20);
+    ret = conntrack_op_for_test(delete, 1, NFCT_Q_DESTROY);
+    ck_assert(ret == 0);
+    sleep(1);
+
+    // verify that hashtable size is reduced to 2 now.
+    ck_assert(g_hash_table_size(conn_store->store) == 2);
+    ct = g_hash_table_lookup(conn_store->store, GUINT_TO_POINTER(3));
+    ck_assert(ct == NULL);
+
+    stop_flag = true;
+    pthread_join(args.tid, NULL);
+}
+END_TEST
+
 Suite *
 conntrack_suite(void)
 {
@@ -746,11 +1060,14 @@ conntrack_suite(void)
     tcase_set_timeout(tc_core, 10);
 
     tcase_add_test(tc_core, test_conntrack_dump);
+    tcase_add_test(tc_core, test_conntrack_dump_for_zone);
     tcase_add_test(tc_core, test_append_ct_to_batch);
     tcase_add_test(tc_core, test_create_batch_conntrack);
     tcase_add_test(tc_core, test_delete_conntrack);
+    tcase_add_test(tc_core, test_delete_conntrack_for_zone);
     tcase_add_test(tc_core, test_conntrack_events_for_src);
     tcase_add_test(tc_core, test_conntrack_events_for_dst);
+    tcase_add_test(tc_core, test_conntrack_events_for_zone);
 
     suite_add_tcase(s, tc_core);
 

--- a/tests/test_conntrack_entry.c
+++ b/tests/test_conntrack_entry.c
@@ -67,15 +67,20 @@ check_attr(int attr, void *exp, struct conntrack_entry *ct)
     case CT_ATTR_L4_SRC_PORT:
     case CT_ATTR_L4_DST_PORT:
     case CT_ATTR_ICMP_SRC_ID:
+    case CT_ATTR_L4_SRC_PORT_REPL:
+    case CT_ATTR_L4_DST_PORT_REPL:
         tmp_u16 = offset;
         exp_u16 = exp;
         ck_assert(*tmp_u16 == *exp_u16);
         break;
     case CT_ATTR_L3_SRC_V4:
     case CT_ATTR_L3_DST_V4:
+    case CT_ATTR_L3_SRC_V4_REPL:
+    case CT_ATTR_L3_DST_V4_REPL:
     case CT_ATTR_TIMEOUT:
     case CT_ATTR_MARK:
     case CT_ATTR_STATUS:
+    
         tmp_u32 = offset;
         exp_u32 = exp;
         ck_assert(*tmp_u32 == *exp_u32);
@@ -107,6 +112,14 @@ START_TEST(test_conntrack_entry_new)
 }
 END_TEST
 
+/*
+ * Zone-mode behaviour (the SAVE_IPS_OP vs SAVE_PORT_ZONE_OP branch and the
+ * is_zone_only_slot() filtering) is driven purely by op_type, not by the L4
+ * protocol: the reply slots are populated from generic NF attributes and the
+ * mode selection runs the same codepath for TCP/UDP/ICMP alike. So exercising
+ * both modes once here is enough; repeating it in the UDP/ICMP tests would only
+ * re-cover the identical op_type logic without adding any new coverage.
+ */
 START_TEST(test_conntrack_entry_from_nf_conntrack_without_label_tcp)
 {
     struct nf_conntrack *ct;
@@ -116,6 +129,8 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_without_label_tcp)
     uint8_t l4proto = IPPROTO_TCP;
     uint16_t src_port = htons(20);
     uint16_t dst_port = htons(10);
+    uint16_t repl_src_port = htons(30);
+    uint16_t repl_dst_port = htons(40);
     uint8_t tcp_state = TCP_CONNTRACK_SYN_SENT;
     uint32_t timeout = 100;
 
@@ -130,8 +145,14 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_without_label_tcp)
     nfct_set_attr_u16(ct, ATTR_PORT_DST, dst_port);
     nfct_set_attr_u8(ct, ATTR_TCP_STATE, tcp_state);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
+    nfct_set_attr_u32(ct, ATTR_REPL_IPV4_SRC, inet_addr("3.3.3.3"));
+    nfct_set_attr_u32(ct, ATTR_REPL_IPV4_DST, inet_addr("4.4.4.4"));
+    nfct_set_attr_u16(ct, ATTR_REPL_PORT_SRC, repl_src_port);
+    nfct_set_attr_u16(ct, ATTR_REPL_PORT_DST, repl_dst_port);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    /* IP mode: legacy slots present; zone-only reply slots are skipped to
+     * keep the payload byte-identical to the ip-mode wire format. */
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -144,6 +165,31 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_without_label_tcp)
     check_attr(CT_ATTR_L4_DST_PORT, &dst_port, entry);
     check_attr(CT_ATTR_TCP_STATE, &tcp_state, entry);
     check_attr(CT_ATTR_TIMEOUT, &timeout, entry);
+    ck_assert(is_set_in_bitmap(entry->bitmap, CT_ATTR_L3_SRC_V4_REPL) == 0);
+    ck_assert(is_set_in_bitmap(entry->bitmap, CT_ATTR_L3_DST_V4_REPL) == 0);
+    ck_assert(is_set_in_bitmap(entry->bitmap, CT_ATTR_L4_SRC_PORT_REPL) == 0);
+    ck_assert(is_set_in_bitmap(entry->bitmap, CT_ATTR_L4_DST_PORT_REPL) == 0);
+    conntrack_entry_destroy(entry);
+
+    /* Zone mode: same legacy slots PLUS the NAT'd reply slots. */
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_PORT_ZONE_OP);
+    ck_assert(entry != NULL);
+
+    inet_aton("1.1.1.1", &inp);
+    check_attr(CT_ATTR_L3_SRC_V4, &(inp.s_addr), entry);
+    inet_aton("2.2.2.2", &inp);
+    check_attr(CT_ATTR_L3_DST_V4, &(inp.s_addr), entry);
+    check_attr(CT_ATTR_L4_SRC_PORT, &src_port, entry);
+    check_attr(CT_ATTR_L4_DST_PORT, &dst_port, entry);
+    check_attr(CT_ATTR_TCP_STATE, &tcp_state, entry);
+    check_attr(CT_ATTR_TIMEOUT, &timeout, entry);
+    inet_aton("3.3.3.3", &inp);
+    check_attr(CT_ATTR_L3_SRC_V4_REPL, &(inp.s_addr), entry);
+    inet_aton("4.4.4.4", &inp);
+    check_attr(CT_ATTR_L3_DST_V4_REPL, &(inp.s_addr), entry);
+    check_attr(CT_ATTR_L4_SRC_PORT_REPL, &repl_src_port, entry);
+    check_attr(CT_ATTR_L4_DST_PORT_REPL, &repl_dst_port, entry);
+    conntrack_entry_destroy(entry);
 }
 END_TEST
 
@@ -169,7 +215,7 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_without_label_udp)
     nfct_set_attr_u16(ct, ATTR_PORT_DST, dst_port);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -208,7 +254,7 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_without_label_icmp)
     nfct_set_attr_u8(ct, ATTR_ICMP_TYPE, type);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -258,7 +304,7 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_with_label_tcp)
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
     nfct_set_attr(ct, ATTR_CONNLABELS, label);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -306,7 +352,7 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_with_label_udp)
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
     nfct_set_attr(ct, ATTR_CONNLABELS, label);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -355,7 +401,7 @@ START_TEST(test_conntrack_entry_from_nf_conntrack_with_label_icmp)
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
     nfct_set_attr(ct, ATTR_CONNLABELS, label);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -400,7 +446,7 @@ START_TEST(test_get_conntrack_entry_from_update_attr_added)
     nfct_set_attr_u8(ct, ATTR_TCP_STATE, tcp_state);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     updated_ct = nfct_clone(ct);
@@ -413,7 +459,7 @@ START_TEST(test_get_conntrack_entry_from_update_attr_added)
     nfct_bitmask_set_bit(label, 96);
     nfct_set_attr(updated_ct, ATTR_CONNLABELS, label);
 
-    updated_entry = get_conntrack_entry_from_update(entry, updated_ct);
+    updated_entry = get_conntrack_entry_from_update(entry, updated_ct, SAVE_IPS_OP);
     ck_assert(updated_entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -457,13 +503,13 @@ START_TEST(test_get_conntrack_entry_from_update_attr_updated)
     nfct_set_attr_u8(ct, ATTR_TCP_STATE, tcp_state);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, timeout);
 
-    entry = conntrack_entry_from_nf_conntrack(ct);
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
     ck_assert(entry != NULL);
 
     updated_ct = nfct_clone(ct);
     nfct_set_attr_u8(updated_ct, ATTR_TCP_STATE, new_tcp_state);
 
-    updated_entry = get_conntrack_entry_from_update(entry, updated_ct);
+    updated_entry = get_conntrack_entry_from_update(entry, updated_ct, SAVE_IPS_OP);
     ck_assert(updated_entry != NULL);
 
     inet_aton("1.1.1.1", &inp);
@@ -503,6 +549,38 @@ START_TEST(test_conntrack_entry_destroy_g_wrapper)
 }
 END_TEST
 
+START_TEST(test_conntrack_entry_from_nf_conntrack_null)
+{
+    /* A NULL nf_conntrack must be rejected in both sub-modes. */
+    ck_assert(conntrack_entry_from_nf_conntrack(NULL, SAVE_IPS_OP) == NULL);
+    ck_assert(conntrack_entry_from_nf_conntrack(NULL, SAVE_PORT_ZONE_OP) == NULL);
+}
+END_TEST
+
+START_TEST(test_get_conntrack_entry_from_update_null)
+{
+    struct nf_conntrack *ct;
+    struct conntrack_entry *entry;
+
+    ct = nfct_new();
+    ck_assert(ct != NULL);
+    nfct_set_attr_u8(ct, ATTR_L3PROTO, AF_INET);
+    nfct_set_attr_u32(ct, ATTR_IPV4_SRC, inet_addr("1.1.1.1"));
+    nfct_set_attr_u32(ct, ATTR_IPV4_DST, inet_addr("2.2.2.2"));
+    nfct_set_attr_u8(ct, ATTR_L4PROTO, IPPROTO_TCP);
+
+    entry = conntrack_entry_from_nf_conntrack(ct, SAVE_IPS_OP);
+    ck_assert(entry != NULL);
+
+    /* Either operand being NULL must yield NULL, not a crash. */
+    ck_assert(get_conntrack_entry_from_update(NULL, ct, SAVE_IPS_OP) == NULL);
+    ck_assert(get_conntrack_entry_from_update(entry, NULL, SAVE_IPS_OP) == NULL);
+
+    conntrack_entry_destroy(entry);
+    nfct_destroy(ct);
+}
+END_TEST
+
 Suite *
 conntrack_entry_suite(void)
 {
@@ -525,6 +603,8 @@ conntrack_entry_suite(void)
     tcase_add_test(tc_core, test_get_conntrack_entry_from_update_attr_updated);
     tcase_add_test(tc_core, test_conntrack_entry_destroy);
     tcase_add_test(tc_core, test_conntrack_entry_destroy_g_wrapper);
+    tcase_add_test(tc_core, test_conntrack_entry_from_nf_conntrack_null);
+    tcase_add_test(tc_core, test_get_conntrack_entry_from_update_null);
 
     suite_add_tcase(s, tc_core);
 

--- a/tests/test_conntrack_store.c
+++ b/tests/test_conntrack_store.c
@@ -19,6 +19,9 @@
 #include "conntrack_store.h"
 
 // ========================= START of dummy functions =========================
+// records the op_type the store forwarded to the entry builders
+static enum save_mode_op_type last_op_type_seen;
+
 void
 conntrack_entry_destroy_g_wrapper(void *obj)
 {
@@ -32,9 +35,11 @@ conntrack_entry_destroy_g_wrapper(void *obj)
  * CT-MARK - 0: return correct entry
 * */
 struct conntrack_entry *
-conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct)
+conntrack_entry_from_nf_conntrack(const struct nf_conntrack *ct,
+                                  enum save_mode_op_type op_type)
 {
     struct conntrack_entry *entry = g_malloc(sizeof(struct conntrack_entry));
+    last_op_type_seen = op_type;
     entry->data_size = nfct_get_attr_u32(ct, ATTR_TIMEOUT);
     uint32_t ct_mark = nfct_get_attr_u32(ct, ATTR_MARK);
 
@@ -46,9 +51,11 @@ conntrack_entry_from_nf_conntrack(struct nf_conntrack *ct)
 
 struct conntrack_entry *
 get_conntrack_entry_from_update(struct conntrack_entry *e,
-                                struct nf_conntrack *ct)
+                                const struct nf_conntrack *ct,
+                                enum save_mode_op_type op_type)
 {
     struct conntrack_entry *entry = g_malloc(sizeof(struct conntrack_entry));
+    last_op_type_seen = op_type;
     entry->data_size = nfct_get_attr_u32(ct, ATTR_TIMEOUT);
     uint32_t ct_mark = nfct_get_attr_u32(ct, ATTR_MARK);
     if (ct_mark == 1)
@@ -93,7 +100,7 @@ START_TEST(test_update_conntrack_store_new_event)
     nfct_set_attr_u32(ct, ATTR_MARK, 0);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
-    update_conntrack_store(store, ct, NFCT_T_NEW);
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 1);
 
@@ -102,6 +109,7 @@ START_TEST(test_update_conntrack_store_new_event)
 
     ck_assert(ct_entry != NULL); // entry should be present in the hashtable
     ck_assert(ct_entry->data_size == 100); // this should be equal to timeout
+    ck_assert(last_op_type_seen == SAVE_IPS_OP); // op_type forwarded to entry builder
 }
 END_TEST
 
@@ -129,7 +137,7 @@ START_TEST(test_update_conntrack_store_new_event_ct_entry_failed)
     nfct_set_attr_u32(ct, ATTR_MARK, 1);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
-    update_conntrack_store(store, ct, NFCT_T_NEW);
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
     const gpointer key = GINT_TO_POINTER(t);
@@ -157,7 +165,7 @@ START_TEST(test_update_conntrack_store_new_event_ct_entry_invalid_id)
     nfct_set_attr_u32(ct, ATTR_MARK, 0);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
-    update_conntrack_store(store, ct, NFCT_T_NEW);
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 }
@@ -186,11 +194,11 @@ START_TEST(test_update_conntrack_store_update_event)
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
     // first create an entry in the store
-    update_conntrack_store(store, ct, NFCT_T_NEW);
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_IPS_OP);
 
     // update the entry
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 200);
-    update_conntrack_store(store, ct, NFCT_T_UPDATE);
+    update_conntrack_store(store, ct, NFCT_T_UPDATE, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 1);
     const gpointer key = GINT_TO_POINTER(t);
@@ -225,7 +233,7 @@ START_TEST(test_update_conntrack_store_update_event_for_non_existent_entry)
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 
     // Directly send the update
-    update_conntrack_store(store, ct, NFCT_T_UPDATE);
+    update_conntrack_store(store, ct, NFCT_T_UPDATE, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 1);
     const gpointer key = GINT_TO_POINTER(t);
@@ -257,7 +265,7 @@ START_TEST(test_update_conntrack_store_update_event_ct_entry_failed)
     nfct_set_attr_u32(ct, ATTR_MARK, 0);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
-    update_conntrack_store(store, ct, NFCT_T_NEW);
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_IPS_OP);
     ck_assert_int_eq(g_hash_table_size(store->store), 1);
 
     // send the update, but make get_conntrack_entry_from_update to return NULL
@@ -265,7 +273,7 @@ START_TEST(test_update_conntrack_store_update_event_ct_entry_failed)
 
     // this makes the dummy fn get_conntrack_entry_from_update return NULL
     nfct_set_attr_u32(ct, ATTR_MARK, 1);
-    update_conntrack_store(store, ct, NFCT_T_UPDATE);
+    update_conntrack_store(store, ct, NFCT_T_UPDATE, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 1);
     const gpointer key = GINT_TO_POINTER(t);
@@ -294,7 +302,7 @@ START_TEST(test_update_conntrack_store_update_event_ct_entry_invalid_id)
     nfct_set_attr_u32(ct, ATTR_MARK, 0);
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
-    update_conntrack_store(store, ct, NFCT_T_UPDATE);
+    update_conntrack_store(store, ct, NFCT_T_UPDATE, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 }
@@ -321,10 +329,10 @@ START_TEST(test_update_conntrack_store_destroy_event)
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
     // first create an entry in the store
-    update_conntrack_store(store, ct, NFCT_T_NEW);
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_IPS_OP);
 
     // destroy the entry
-    update_conntrack_store(store, ct, NFCT_T_DESTROY);
+    update_conntrack_store(store, ct, NFCT_T_DESTROY, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 }
@@ -353,7 +361,7 @@ START_TEST(test_update_conntrack_store_destroy_event_non_existent_entry)
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 
     // Directly send destroy with creating the entry.
-    update_conntrack_store(store, ct, NFCT_T_DESTROY);
+    update_conntrack_store(store, ct, NFCT_T_DESTROY, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 }
@@ -379,7 +387,7 @@ START_TEST(test_update_conntrack_store_destroy_event_ct_entry_invalid_id)
     nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
 
     // destroy the entry
-    update_conntrack_store(store, ct, NFCT_T_DESTROY);
+    update_conntrack_store(store, ct, NFCT_T_DESTROY, SAVE_IPS_OP);
 
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
 }
@@ -406,7 +414,7 @@ START_TEST(test_update_conntrack_store_unknown_event)
     nfct_set_attr_u32(ct, ATTR_ID, 10);
 
     // Send an unknown event
-    update_conntrack_store(store, ct, NFCT_T_UNKNOWN);
+    update_conntrack_store(store, ct, NFCT_T_UNKNOWN, SAVE_IPS_OP);
 
     // check no change to hashtable size
     ck_assert_int_eq(g_hash_table_size(store->store), 0);
@@ -435,6 +443,53 @@ START_TEST(test_conntrack_store_destroy)
 }
 END_TEST
 
+START_TEST(test_update_conntrack_store_forwards_zone_op_type)
+{
+    struct conntrack_store *store;
+    struct nf_conntrack *ct;
+    int t = 10;
+
+    store = conntrack_store_new();
+    ck_assert(store != NULL);
+    ck_assert(store->store != NULL);
+
+    ct = nfct_new();
+    nfct_set_attr_u8(ct, ATTR_L3PROTO, AF_INET);
+    nfct_set_attr_u32(ct, ATTR_IPV4_SRC, inet_addr("1.1.1.1"));
+    nfct_set_attr_u32(ct, ATTR_IPV4_DST, inet_addr("2.2.2.2"));
+    nfct_set_attr_u8(ct, ATTR_L4PROTO, IPPROTO_TCP);
+    nfct_set_attr_u32(ct, ATTR_ID, t);
+    nfct_set_attr_u32(ct, ATTR_MARK, 0);
+    nfct_set_attr_u32(ct, ATTR_TIMEOUT, 100);
+
+    // NEW path -> conntrack_entry_from_nf_conntrack receives the mode
+    last_op_type_seen = SAVE_IPS_OP;
+    update_conntrack_store(store, ct, NFCT_T_NEW, SAVE_PORT_ZONE_OP);
+    ck_assert(last_op_type_seen == SAVE_PORT_ZONE_OP);
+
+    // UPDATE (existing entry) path -> get_conntrack_entry_from_update receives the mode
+    last_op_type_seen = SAVE_IPS_OP;
+    nfct_set_attr_u32(ct, ATTR_TIMEOUT, 200);
+    update_conntrack_store(store, ct, NFCT_T_UPDATE, SAVE_PORT_ZONE_OP);
+    ck_assert(last_op_type_seen == SAVE_PORT_ZONE_OP);
+}
+END_TEST
+
+START_TEST(test_update_conntrack_store_null_ct)
+{
+    struct conntrack_store *store;
+
+    store = conntrack_store_new();
+    ck_assert(store != NULL);
+    ck_assert(store->store != NULL);
+
+    // NULL ct must be ignored (no crash) and leave the store untouched
+    update_conntrack_store(store, NULL, NFCT_T_NEW, SAVE_IPS_OP);
+
+    ck_assert_int_eq(g_hash_table_size(store->store), 0);
+}
+END_TEST
+
 Suite *
 conntrack_store_suite(void)
 {
@@ -459,6 +514,8 @@ conntrack_store_suite(void)
     tcase_add_test(tc_core, test_update_conntrack_store_destroy_event_ct_entry_invalid_id);
     tcase_add_test(tc_core, test_update_conntrack_store_unknown_event);
     tcase_add_test(tc_core, test_conntrack_store_destroy);
+    tcase_add_test(tc_core, test_update_conntrack_store_forwards_zone_op_type);
+    tcase_add_test(tc_core, test_update_conntrack_store_null_ct);
 
     suite_add_tcase(s, tc_core);
 

--- a/tests/test_data_template.c
+++ b/tests/test_data_template.c
@@ -39,7 +39,11 @@ int ct_entry_attr_to_size[CT_ATTR_MAX] =
     [CT_ATTR_TIMEOUT] = UINT32_T_SIZE,
     [CT_ATTR_MARK] = UINT32_T_SIZE,
     [CT_ATTR_STATUS] = UINT32_T_SIZE,
-    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS
+    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS,
+    [CT_ATTR_L3_SRC_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L3_DST_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L4_SRC_PORT_REPL] = UINT16_T_SIZE,
+    [CT_ATTR_L4_DST_PORT_REPL] = UINT16_T_SIZE
 };
 // ========================= END of dependencies ==================
 
@@ -48,7 +52,19 @@ START_TEST(test_data_template_new)
     struct data_template *tmpl;
     int i;
 
-    tmpl = data_template_new();
+    /* IP mode advertises only the legacy schema. */
+    tmpl = data_template_new(SAVE_IPS_OP);
+    ck_assert(tmpl != NULL);
+    ck_assert(tmpl->num_bits == CT_ATTR_LEGACY_NUM_BITS);
+    ck_assert(tmpl->payload_size == CT_ATTR_LEGACY_NUM_BITS * UINT8_T_SIZE);
+    ck_assert(tmpl->payload != NULL);
+    for (i = CT_ATTR_MIN; i < CT_ATTR_LEGACY_NUM_BITS; i++) {
+        ck_assert(tmpl->payload[i] == ct_entry_attr_to_size[i]);
+    }
+    data_template_destroy(tmpl);
+
+    /* Zone mode advertises every slot, including NAT'd-reply slots. */
+    tmpl = data_template_new(SAVE_PORT_ZONE_OP);
     ck_assert(tmpl != NULL);
     ck_assert(tmpl->num_bits == CT_ATTR_MAX);
     ck_assert(tmpl->payload_size == CT_ATTR_MAX * UINT8_T_SIZE);
@@ -56,6 +72,7 @@ START_TEST(test_data_template_new)
     for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
         ck_assert(tmpl->payload[i] == ct_entry_attr_to_size[i]);
     }
+    data_template_destroy(tmpl);
 }
 END_TEST
 
@@ -63,19 +80,24 @@ START_TEST(test_data_template_destroy)
 {
     struct data_template *tmpl;
 
-    tmpl = data_template_new();
+    tmpl = data_template_new(SAVE_IPS_OP);
 
-    /* Test 1: Destroying template with payload does not cause core-dump */
+    /* Test 1: Destroying IP mode template with payload does not cause core-dump */
     data_template_destroy(tmpl);
 
-    /* Test 2: Destroying tempalte without any payload does not cause
+    tmpl = data_template_new(SAVE_PORT_ZONE_OP);
+
+    /* Test 2: Destroying zone mode template with payload does not cause core-dump */
+    data_template_destroy(tmpl);
+
+    /* Test 3: Destroying template without any payload does not cause
      * any SIGSEGV
      */
     tmpl = g_malloc(sizeof(struct data_template));
     tmpl->payload = NULL;
     data_template_destroy(tmpl);
 
-    /* Test 3: Destroying NULL template does not cause any SIGSEGV */
+    /* Test 4: Destroying NULL template does not cause any SIGSEGV */
     data_template_destroy(NULL);
 }
 END_TEST

--- a/tests/test_dbus_server.c
+++ b/tests/test_dbus_server.c
@@ -11,6 +11,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
 
 #include <check.h>
 #include <glib.h>
@@ -47,9 +50,18 @@ int batch_size = 0;
 int load_size = 0;
 int fail_netlink = false;
 
+// --- hooks used by the zone-mode coverage below ---
+static enum save_mode_op_type last_save_op_type;        // captured in data_template_new
+int last_appended_zone = -1;                            // captured in append_ct_to_batch (-1 = never)
+bool load_zone_enabled = false;                         // make unmarshal stamp ATTR_ZONE
+uint16_t load_zone = 0;
+enum save_mode_op_type next_save_op_type = SAVE_IPS_OP; // dbus_targs.save_op_type for the next thread
+struct load_mode_config *next_load_config = NULL;       // dbus_targs.load_config for the next thread
+
 struct data_template *
-data_template_new(void)
+data_template_new(enum save_mode_op_type op_type)
 {
+    last_save_op_type = op_type;
     return NULL;
 }
 
@@ -61,13 +73,31 @@ data_template_destroy(struct data_template *data_tmpl)
 
 // this is used in CLEAR ipc only.
 GHashTable *
-create_hashtable_from_ip_list(const char *ip_list[],  int num_ips)
+create_hashtable_from_ip_list(const char *const ip_list[],  int num_ips)
 {
     if (fail_clear) {
         return NULL;
     }
 
     return g_hash_table_new(g_direct_hash, g_direct_equal);
+}
+
+// zone-mode CLEAR path (reuses the same fail_clear knob)
+GHashTable *
+create_hashtable_from_port_zone_pairs(const char *port_zone_strv[],
+                                      int num_entries)
+{
+    if (fail_clear) {
+        return NULL;
+    }
+
+    return g_hash_table_new(g_direct_hash, g_direct_equal);
+}
+
+const char *
+convert_save_mode_op_type_to_string(enum save_mode_op_type op_type)
+{
+    return op_type == SAVE_IPS_OP ? "ips" : "port_zone";
 }
 
 // This is used in save ipc only.
@@ -112,6 +142,9 @@ uint32_t
 unmarshal_conntrack_entry(void *start, struct data_template *data_tmpl,
                           struct nf_conntrack *ct, uint32_t **label)
 {
+    if (load_zone_enabled) {
+        nfct_set_attr_u16(ct, ATTR_ZONE, load_zone);
+    }
     return sizeof(uint32_t);
 }
 
@@ -121,13 +154,16 @@ create_batch_conntrack(struct mnl_socket *nl, struct mnl_nlmsg_batch *batch)
     return -1;
 }
 
-void
+int
 append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
                    uint32_t *label, int seq)
 {
     if (batch_size > 0) {
-        return;
+        return 0;
     }
+
+    last_appended_zone = nfct_attr_is_set(ct, ATTR_ZONE)
+                             ? (int) nfct_get_attr_u16(ct, ATTR_ZONE) : -1;
 
     // For 0 batch_size, append one entry to it.
     struct nlmsghdr *nlh;
@@ -147,6 +183,7 @@ append_ct_to_batch(char *send_buf, struct nf_conntrack *ct,
     nfct_nlmsg_build(nlh, ct);
 
     batch_size++;
+    return 0;
 }
 
 int
@@ -157,6 +194,24 @@ mnl_socket_bind(struct mnl_socket *nl, unsigned int groups, pid_t pid)
     }
 
     return 0;
+}
+
+/*
+ * SO_RCVBUFFORCE (set in connect_to_netlink_conntrack) needs CAP_NET_ADMIN,
+ * which the unprivileged test process does not have. Fake just that one option
+ * so netlink socket setup succeeds and on_load can reach the zone-rewrite
+ * logic; the kernel-facing send (create_batch_conntrack) is stubbed, so nothing
+ * actually touches the kernel. Every other setsockopt call (GIO/D-Bus, libmnl
+ * NETLINK_NO_ENOBUFS) is forwarded to the real syscall so it behaves normally.
+ */
+int
+setsockopt(int fd, int level, int optname, const void *optval, socklen_t optlen)
+{
+    if (level == SOL_SOCKET && optname == SO_RCVBUFFORCE) {
+        return 0;
+    }
+
+    return syscall(SYS_setsockopt, fd, level, optname, optval, optlen);
 }
 //============================================================================
 
@@ -292,10 +347,15 @@ create_dbus_thread(const char *helper_id, int mode, bool *stop_flag)
     struct dbus_targs *args = NULL;
     int ret;
 
-    args = g_malloc(sizeof(struct dbus_targs));
+    args = g_malloc0(sizeof(struct dbus_targs));
     args->helper_id = helper_id;
     args->stop_flag = stop_flag;
     args->mode = mode;
+    args->save_op_type = next_save_op_type;
+    args->load_config = next_load_config;
+    args->should_quit = false;
+    args->loop = NULL;
+    pthread_mutex_init(&args->loop_mu, NULL);
 
     ret = pthread_create(&args->tid, NULL, dbus_server_init, args);
     ck_assert_msg(ret == 0, "Failed to create dbus thread. %s",
@@ -449,6 +509,7 @@ START_TEST(test_src_save_pass_clear_pass)
     ck_assert(ret->size != 0);
     ck_assert_msg(strcmp("save", ret->data) == 0,
                   "expected: save, got: %s\n", ret->data);
+    ck_assert(last_save_op_type == SAVE_IPS_OP); // on_save forwarded IP mode
 
     // prepare ct_del_args
     ct_del_args.clear_called = false;
@@ -547,6 +608,186 @@ START_TEST(test_dst_load_pass)
 }
 END_TEST
 
+START_TEST(test_src_save_zone_pass)
+{
+    const char address[] = "unix:path=/tmp/dbus/system_bus_socket";
+    const char helper_id[] = "helper_test_save";
+    bool stop_flag = false;
+    GDBusConnection *client;
+    GDBusProxy *proxy;
+    struct save_ret *ret;
+
+    client = create_client(address);
+
+    next_save_op_type = SAVE_PORT_ZONE_OP;   // configure zone-mode SAVE
+    pthread_t tid = create_dbus_thread(helper_id, SAVE_MODE, &stop_flag);
+    next_save_op_type = SAVE_IPS_OP;          // restore default for other tests
+    sleep(2);
+
+    proxy = get_dbus_vmstate_proxy(client);
+    fail_marshal = false;
+    last_save_op_type = SAVE_IPS_OP;
+    ret = call_save_for_test(proxy);
+    ck_assert(ret->data != NULL);
+    ck_assert(last_save_op_type == SAVE_PORT_ZONE_OP); // on_save threaded zone mode
+
+    // drive an IP-mode clear so the server loop quits and we can join
+    ct_del_args.op_type = SAVE_IPS_OP;
+    proxy = get_lmct_mgmt_proxy(client);
+    GStrv ips = g_new(char *, 2);
+    ips[0] = g_strdup("1.2.3.4");
+    ips[1] = NULL;
+    fail_clear = false;
+    call_clear_for_test(proxy, ips);
+
+    pthread_join(tid, NULL);
+}
+END_TEST
+
+START_TEST(test_src_clear_zone_pass)
+{
+    const char address[] = "unix:path=/tmp/dbus/system_bus_socket";
+    const char helper_id[] = "helper_test_save";
+    bool stop_flag = false;
+    GDBusConnection *client;
+    GDBusProxy *proxy;
+
+    client = create_client(address);
+    pthread_t tid = create_dbus_thread(helper_id, SAVE_MODE, &stop_flag);
+    sleep(2);
+
+    ct_del_args.op_type = SAVE_PORT_ZONE_OP;   // select zone clear path
+    ct_del_args.clear_called = false;
+
+    proxy = get_lmct_mgmt_proxy(client);
+    GStrv pz = g_new(char *, 3);               // paired (port_uuid, zone)
+    pz[0] = g_strdup("port-uuid-1");
+    pz[1] = g_strdup("5");
+    pz[2] = NULL;
+
+    fail_clear = false;
+    call_clear_for_test(proxy, pz);
+
+    ck_assert(ct_del_args.clear_called == true);
+    ck_assert(ct_del_args.zones_on_host != NULL);
+
+    ct_del_args.op_type = SAVE_IPS_OP;         // restore for other tests
+    pthread_join(tid, NULL);
+}
+END_TEST
+
+START_TEST(test_src_clear_zone_fail)
+{
+    const char address[] = "unix:path=/tmp/dbus/system_bus_socket";
+    const char helper_id[] = "helper_test_save";
+    bool stop_flag = false;
+    GDBusConnection *client;
+    GDBusProxy *proxy;
+
+    client = create_client(address);
+    pthread_t tid = create_dbus_thread(helper_id, SAVE_MODE, &stop_flag);
+    sleep(2);
+
+    ct_del_args.op_type = SAVE_PORT_ZONE_OP;
+    ct_del_args.clear_called = false;
+
+    proxy = get_lmct_mgmt_proxy(client);
+    GStrv pz = g_new(char *, 2);               // odd length (1 entry) -> rejected
+    pz[0] = g_strdup("port-uuid-1");
+    pz[1] = NULL;
+
+    fail_clear = false;
+    call_clear_for_test(proxy, pz);
+
+    ck_assert(ct_del_args.clear_called == false); // pairing guard fired
+
+    ct_del_args.op_type = SAVE_IPS_OP;
+    pthread_join(tid, NULL);
+}
+END_TEST
+
+START_TEST(test_dst_load_zone_pass)
+{
+    const char address[] = "unix:path=/tmp/dbus/system_bus_socket";
+    const char helper_id[] = "helper_test_save";
+    uint32_t data[3] = { 1, 2, 3 };
+
+    GDBusConnection *client;
+    GDBusProxy *proxy;
+    bool stop_flag = false;
+
+    // zone-mode LOAD config: old_zone 5 -> new_zone 10
+    struct load_mode_config zone_cfg;
+    zone_cfg.op_type = LOAD_PORT_ZONE_OP;
+    zone_cfg.src_dst_zone_map = g_hash_table_new(g_direct_hash, g_direct_equal);
+    g_hash_table_insert(zone_cfg.src_dst_zone_map,
+                        GUINT_TO_POINTER(5u), GUINT_TO_POINTER(10u));
+
+    client = create_client(address);
+    fail_netlink = false;
+    next_load_config = &zone_cfg;
+    pthread_t tid = create_dbus_thread(helper_id, LOAD_MODE, &stop_flag);
+    next_load_config = NULL;
+    sleep(2);
+
+    fail_load = false;
+    batch_size = 0;
+    load_size = sizeof(uint32_t) * 3;   // one entry processed
+    load_zone_enabled = true;
+    load_zone = 5;
+    last_appended_zone = -1;
+
+    proxy = get_dbus_vmstate_proxy(client);
+    call_load_for_test(proxy, data, load_size);
+    pthread_join(tid, NULL);
+
+    ck_assert_int_eq(last_appended_zone, 10); // 5 was rewritten to 10
+
+    load_zone_enabled = false;
+    g_hash_table_destroy(zone_cfg.src_dst_zone_map);
+}
+END_TEST
+
+START_TEST(test_dst_load_zone_drop)
+{
+    const char address[] = "unix:path=/tmp/dbus/system_bus_socket";
+    const char helper_id[] = "helper_test_save";
+    uint32_t data[3] = { 1, 2, 3 };
+
+    GDBusConnection *client;
+    GDBusProxy *proxy;
+    bool stop_flag = false;
+
+    // zone-mode LOAD config with an EMPTY map: entry's zone won't be found
+    struct load_mode_config zone_cfg;
+    zone_cfg.op_type = LOAD_PORT_ZONE_OP;
+    zone_cfg.src_dst_zone_map = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    client = create_client(address);
+    fail_netlink = false;
+    next_load_config = &zone_cfg;
+    pthread_t tid = create_dbus_thread(helper_id, LOAD_MODE, &stop_flag);
+    next_load_config = NULL;
+    sleep(2);
+
+    fail_load = false;
+    batch_size = 0;
+    load_size = sizeof(uint32_t) * 3;
+    load_zone_enabled = true;
+    load_zone = 5;            // not present in the map -> drop
+    last_appended_zone = -1;
+
+    proxy = get_dbus_vmstate_proxy(client);
+    call_load_for_test(proxy, data, load_size);
+    pthread_join(tid, NULL);
+
+    ck_assert_int_eq(last_appended_zone, -1); // entry dropped, never appended
+
+    load_zone_enabled = false;
+    g_hash_table_destroy(zone_cfg.src_dst_zone_map);
+}
+END_TEST
+
 Suite *
 dbus_server_suite(void)
 {
@@ -563,9 +804,14 @@ dbus_server_suite(void)
     tcase_add_test(tc_core, test_src_save_fail_clear_fail);
     tcase_add_test(tc_core, test_src_save_fail_clear_pass);
     tcase_add_test(tc_core, test_src_save_pass_clear_pass);
+    tcase_add_test(tc_core, test_src_save_zone_pass);
+    tcase_add_test(tc_core, test_src_clear_zone_pass);
+    tcase_add_test(tc_core, test_src_clear_zone_fail);
     tcase_add_test(tc_core, test_dst_load_payload_zero);
     tcase_add_test(tc_core, test_dst_load_netlink_fail);
     tcase_add_test(tc_core, test_dst_load_pass);
+    tcase_add_test(tc_core, test_dst_load_zone_pass);
+    tcase_add_test(tc_core, test_dst_load_zone_drop);
 
     suite_add_tcase(s, tc_core);
 

--- a/tests/test_marshal.c
+++ b/tests/test_marshal.c
@@ -190,9 +190,9 @@ START_TEST(test_marshal_for_zone)
     struct conntrack_store *store;
     store = create_conntrack_store();
 
-    /* A realistic zone-mode entry: original 5-tuple + CT zone + the NAT'd
-     * reply 5-tuple. marshal is schema-agnostic (it copies the bitmap and
-     * data blob verbatim). */
+    // A realistic zone-mode entry: original 5-tuple + CT zone + the NAT'd
+    // reply 5-tuple. marshal is schema-agnostic (it copies the bitmap and
+    // data blob verbatim).
     uint8_t entry_data[26]; // 4+4 (orig ips) + 2 (zone) + 2+2 (orig ports)
                             // + 4+4 (repl ips) + 2+2 (repl ports).
     uint8_t *p;
@@ -239,7 +239,7 @@ START_TEST(test_marshal_for_zone)
                     ((BITMAP_NUM_WORDS * WORD_SIZE) +
                      sizeof(entry_data));                     // one entry
     ck_assert(exp_data_size == data_size);
-
+    // check the values written in the buffer
     // Check 1: total size is correct.
     uint32_t read_data_size;
     memcpy(&read_data_size, buffer, sizeof(read_data_size));
@@ -268,7 +268,7 @@ START_TEST(test_marshal_for_zone)
     ck_assert(memcmp(buffer, entry_data, sizeof(entry_data)) == 0);
     buffer += sizeof(entry_data);
 
-    // Check we've reached end of buffer.
+    // Check we've reached end of buffer
     ck_assert(buffer == buffer_end);
 }
 END_TEST

--- a/tests/test_marshal.c
+++ b/tests/test_marshal.c
@@ -43,7 +43,11 @@ int ct_entry_attr_to_size[CT_ATTR_MAX] =
     [CT_ATTR_TIMEOUT] = UINT32_T_SIZE,
     [CT_ATTR_MARK] = UINT32_T_SIZE,
     [CT_ATTR_STATUS] = UINT32_T_SIZE,
-    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS
+    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS,
+    [CT_ATTR_L3_SRC_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L3_DST_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L4_SRC_PORT_REPL] = UINT16_T_SIZE,
+    [CT_ATTR_L4_DST_PORT_REPL] = UINT16_T_SIZE
 };
 
 struct data_template *
@@ -174,6 +178,97 @@ START_TEST(test_marshal)
     ck_assert(exp_d3 == d3);
 
     // check we've reached end of buffer
+    ck_assert(buffer == buffer_end);
+}
+END_TEST
+
+START_TEST(test_marshal_for_zone)
+{
+    init_lmct_config();
+    struct data_template *tmpl;
+    tmpl = create_template();
+    struct conntrack_store *store;
+    store = create_conntrack_store();
+
+    /* A realistic zone-mode entry: original 5-tuple + CT zone + the NAT'd
+     * reply 5-tuple. marshal is schema-agnostic (it copies the bitmap and
+     * data blob verbatim). */
+    uint8_t entry_data[26]; // 4+4 (orig ips) + 2 (zone) + 2+2 (orig ports)
+                            // + 4+4 (repl ips) + 2+2 (repl ports).
+    uint8_t *p;
+    uint32_t src_ip = 2;
+    uint32_t dst_ip = 3;
+    uint16_t zone = 10;
+    uint16_t src_port = 1024;
+    uint16_t dst_port = 9090;
+    uint32_t repl_src_ip = 4;
+    uint32_t repl_dst_ip = 5;
+    uint16_t repl_src_port = 5555;
+    uint16_t repl_dst_port = 6666;
+
+    p = entry_data;
+    memcpy(p, &src_ip, sizeof(src_ip));             p += sizeof(src_ip);
+    memcpy(p, &dst_ip, sizeof(dst_ip));             p += sizeof(dst_ip);
+    memcpy(p, &zone, sizeof(zone));                 p += sizeof(zone);
+    memcpy(p, &src_port, sizeof(src_port));         p += sizeof(src_port);
+    memcpy(p, &dst_port, sizeof(dst_port));         p += sizeof(dst_port);
+    memcpy(p, &repl_src_ip, sizeof(repl_src_ip));   p += sizeof(repl_src_ip);
+    memcpy(p, &repl_dst_ip, sizeof(repl_dst_ip));   p += sizeof(repl_dst_ip);
+    memcpy(p, &repl_src_port, sizeof(repl_src_port)); p += sizeof(repl_src_port);
+    memcpy(p, &repl_dst_port, sizeof(repl_dst_port)); p += sizeof(repl_dst_port);
+
+    struct conntrack_entry *e1;
+    e1 = create_conntrack_entry(entry_data, sizeof(entry_data));
+    e1->bitmap[0] = (1 << CT_ATTR_L3_SRC_V4)        |
+                    (1 << CT_ATTR_L3_DST_V4)        |
+                    (1 << CT_ATTR_ZONE)             |
+                    (1 << CT_ATTR_L4_SRC_PORT)      |
+                    (1 << CT_ATTR_L4_DST_PORT)      |
+                    (1 << CT_ATTR_L3_SRC_V4_REPL)   |
+                    (1 << CT_ATTR_L3_DST_V4_REPL)   |
+                    (1 << CT_ATTR_L4_SRC_PORT_REPL) |
+                    (1 << CT_ATTR_L4_DST_PORT_REPL);
+    g_hash_table_insert(store->store, GINT_TO_POINTER(1), e1);
+
+    uint32_t data_size;
+    uint32_t exp_data_size;
+    void *buffer = marshal(store, tmpl, &data_size);
+    void *buffer_end = buffer + data_size;
+    exp_data_size = sizeof(data_size) +                       // data size
+                    (UINT8_T_SIZE + tmpl->payload_size) +     // template
+                    ((BITMAP_NUM_WORDS * WORD_SIZE) +
+                     sizeof(entry_data));                     // one entry
+    ck_assert(exp_data_size == data_size);
+
+    // Check 1: total size is correct.
+    uint32_t read_data_size;
+    memcpy(&read_data_size, buffer, sizeof(read_data_size));
+    buffer += sizeof(read_data_size);
+    ck_assert(read_data_size == exp_data_size);
+
+    // Check 2: template is correctly marshalled (covers zone + reply slots).
+    uint8_t tmpl_bits;
+    memcpy(&tmpl_bits, buffer, sizeof(tmpl_bits));
+    buffer += sizeof(tmpl_bits);
+    ck_assert(tmpl_bits == tmpl->num_bits);
+
+    uint8_t *payload = g_malloc(tmpl->payload_size);
+    memcpy(payload, buffer, tmpl->payload_size);
+    buffer += tmpl->payload_size;
+    int i;
+    for (i = CT_ATTR_MIN; i < CT_ATTR_MAX; i++) {
+        ck_assert(tmpl->payload[i] == payload[i]);
+    }
+
+    // Check 3: the non-zero bitmap is marshalled verbatim.
+    ck_assert(memcmp(buffer, e1->bitmap, BITMAP_NUM_WORDS * WORD_SIZE) == 0);
+    buffer += (BITMAP_NUM_WORDS * WORD_SIZE);
+
+    // Check 4: the entry data blob is marshalled verbatim.
+    ck_assert(memcmp(buffer, entry_data, sizeof(entry_data)) == 0);
+    buffer += sizeof(entry_data);
+
+    // Check we've reached end of buffer.
     ck_assert(buffer == buffer_end);
 }
 END_TEST
@@ -330,6 +425,7 @@ marshal_suite(void)
     tc_core = tcase_create("Core");
 
     tcase_add_test(tc_core, test_marshal);
+    tcase_add_test(tc_core, test_marshal_for_zone);
     tcase_add_test(tc_core, test_marshal_empty_conntrack_store);
     tcase_add_test(tc_core, test_marshal_null_conntrack_store);
     tcase_add_test(tc_core, test_marshal_null_template);

--- a/tests/test_unmarshal.c
+++ b/tests/test_unmarshal.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <check.h>
 
 #include <glib.h>
@@ -41,6 +42,10 @@ enum nf_conntrack_attr ct_entry_attr_to_nf_attr[CT_ATTR_MAX] =
     [CT_ATTR_MARK] = ATTR_MARK,
     [CT_ATTR_STATUS] = ATTR_STATUS,
     [CT_ATTR_LABEL] = ATTR_CONNLABELS,
+    [CT_ATTR_L3_SRC_V4_REPL] = ATTR_REPL_IPV4_SRC,
+    [CT_ATTR_L3_DST_V4_REPL] = ATTR_REPL_IPV4_DST,
+    [CT_ATTR_L4_SRC_PORT_REPL] = ATTR_REPL_PORT_SRC,
+    [CT_ATTR_L4_DST_PORT_REPL] = ATTR_REPL_PORT_DST,
 };
 
 int ct_entry_attr_to_size[CT_ATTR_MAX] =
@@ -65,7 +70,11 @@ int ct_entry_attr_to_size[CT_ATTR_MAX] =
     [CT_ATTR_TIMEOUT] = UINT32_T_SIZE,
     [CT_ATTR_MARK] = UINT32_T_SIZE,
     [CT_ATTR_STATUS] = UINT32_T_SIZE,
-    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS
+    [CT_ATTR_LABEL] = UINT32_T_SIZE * CT_LABEL_NUM_WORDS,
+    [CT_ATTR_L3_SRC_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L3_DST_V4_REPL] = UINT32_T_SIZE,
+    [CT_ATTR_L4_SRC_PORT_REPL] = UINT16_T_SIZE,
+    [CT_ATTR_L4_DST_PORT_REPL] = UINT16_T_SIZE
 };
 
 struct data_template *
@@ -235,7 +244,7 @@ START_TEST(test_unmarshal_conntrack_entry_unsupported_bit)
                 (1 << CT_ATTR_STATUS)    |
                 (1 << CT_ATTR_L3_SRC_V4) |
                 (1 << CT_ATTR_L3_DST_V4) |
-                (1 << (CT_ATTR_MAX + 1)); // this is an unsupported bit.
+                (1 << CT_ATTR_MAX);       // this is an unsupported bit.
                                           // assume it to be ATTR_DNAT_IPV4
 
     bitmap[1] = 0;
@@ -262,7 +271,8 @@ START_TEST(test_unmarshal_conntrack_entry_unsupported_bit)
 
     bytes_read = unmarshal_conntrack_entry(data, tmpl, ct, NULL);
 
-    ck_assert(bytes_read == 28);
+    /* 8 (bitmap) + 5x4 (known attrs) + 4 (skipped unsupported attr) = 32. */
+    ck_assert(bytes_read == 32);
     ck_assert(nfct_get_attr_u32(ct, ATTR_IPV4_SRC) == 2);
     ck_assert(nfct_get_attr_u32(ct, ATTR_IPV4_DST) == 3);
     ck_assert(nfct_get_attr_u32(ct, ATTR_TIMEOUT) == 4);
@@ -271,6 +281,72 @@ START_TEST(test_unmarshal_conntrack_entry_unsupported_bit)
     ck_assert(nfct_attr_is_set(ct, ATTR_DNAT_IPV4) == 0); // this should not
                                                           // be set since it
                                                           // is unsupported.
+}
+END_TEST
+
+START_TEST(test_unmarshal_conntrack_entry_for_zone)
+{
+    /* A zone-mode payload: original 5-tuple + CT zone + the NAT'd reply
+     * 5-tuple. */
+    uint32_t databuf[9]; // 36 bytes, 4-byte aligned; we use 34.
+    uint8_t *data = (uint8_t *)databuf;
+    uint8_t *p;
+    uint32_t bytes_read;
+    struct data_template *tmpl;
+    struct nf_conntrack *ct;
+
+    uint32_t bitmap[2];
+    uint32_t src_ip = 2;
+    uint32_t dst_ip = 3;
+    uint16_t zone = 10;
+    uint16_t src_port = 1024;
+    uint16_t dst_port = 9090;
+    uint32_t repl_src_ip = 4;
+    uint32_t repl_dst_ip = 5;
+    uint16_t repl_src_port = 5555;
+    uint16_t repl_dst_port = 6666;
+
+    bitmap[0] = (1 << CT_ATTR_L3_SRC_V4)        |
+                (1 << CT_ATTR_L3_DST_V4)        |
+                (1 << CT_ATTR_ZONE)             |
+                (1 << CT_ATTR_L4_SRC_PORT)      |
+                (1 << CT_ATTR_L4_DST_PORT)      |
+                (1 << CT_ATTR_L3_SRC_V4_REPL)   |
+                (1 << CT_ATTR_L3_DST_V4_REPL)   |
+                (1 << CT_ATTR_L4_SRC_PORT_REPL) |
+                (1 << CT_ATTR_L4_DST_PORT_REPL);
+    bitmap[1] = 0;
+
+    // Bitmap first, then the attribute values in ascending bit order.
+    p = data;
+    memcpy(p, bitmap, sizeof(bitmap));             p += sizeof(bitmap);
+    memcpy(p, &src_ip, sizeof(src_ip));             p += sizeof(src_ip);
+    memcpy(p, &dst_ip, sizeof(dst_ip));             p += sizeof(dst_ip);
+    memcpy(p, &zone, sizeof(zone));                 p += sizeof(zone);
+    memcpy(p, &src_port, sizeof(src_port));         p += sizeof(src_port);
+    memcpy(p, &dst_port, sizeof(dst_port));         p += sizeof(dst_port);
+    memcpy(p, &repl_src_ip, sizeof(repl_src_ip));   p += sizeof(repl_src_ip);
+    memcpy(p, &repl_dst_ip, sizeof(repl_dst_ip));   p += sizeof(repl_dst_ip);
+    memcpy(p, &repl_src_port, sizeof(repl_src_port)); p += sizeof(repl_src_port);
+    memcpy(p, &repl_dst_port, sizeof(repl_dst_port)); p += sizeof(repl_dst_port);
+
+    tmpl = create_template();
+    ct = nfct_new();
+
+    bytes_read = unmarshal_conntrack_entry(data, tmpl, ct, NULL);
+
+    /* 8 (bitmap) + 4+4 (orig ips) + 2 (zone) + 2+2 (orig ports)
+     * + 4+4 (repl ips) + 2+2 (repl ports) = 34. */
+    ck_assert(bytes_read == 34);
+    ck_assert(nfct_get_attr_u32(ct, ATTR_IPV4_SRC) == src_ip);
+    ck_assert(nfct_get_attr_u32(ct, ATTR_IPV4_DST) == dst_ip);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_ZONE) == zone);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_PORT_SRC) == src_port);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_PORT_DST) == dst_port);
+    ck_assert(nfct_get_attr_u32(ct, ATTR_REPL_IPV4_SRC) == repl_src_ip);
+    ck_assert(nfct_get_attr_u32(ct, ATTR_REPL_IPV4_DST) == repl_dst_ip);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_REPL_PORT_SRC) == repl_src_port);
+    ck_assert(nfct_get_attr_u16(ct, ATTR_REPL_PORT_DST) == repl_dst_port);
 }
 END_TEST
 
@@ -290,6 +366,7 @@ unmarshal_suite(void)
     tcase_add_test(tc_core, test_unmarshal_conntrack_entry);
     tcase_add_test(tc_core, test_unmarshal_conntrack_entry_with_label);
     tcase_add_test(tc_core, test_unmarshal_conntrack_entry_unsupported_bit);
+    tcase_add_test(tc_core, test_unmarshal_conntrack_entry_for_zone);
 
     suite_add_tcase(s, tc_core);
 


### PR DESCRIPTION
## Command-Line Interface Updates
- Automatically detects if the daemon is in legacy "IP-based" mode or the new "port + CT-zone" mode based on argument counts.
- Ensures backward compatibility so that existing callers using the old format continue to function without changes.

## Zone-Based Filtering & Entry Capture

- Implements a new SAVE path that identifies conntrack entries by CT zone rather than VM IP.
- Adapts entry validation to the active mode: legacy mode rejects entries with zones, while the new zone mode requires them for accurate matching.
- Captures reply-side attributes (L3_SRC_V4_REPL, L3_DST_V4_REPL, etc.) to ensure NAT’d entries are preserved when migration happens.

## Zone Remapping on Load

- Rewrites incoming entry zones from old values to new values during the LOAD process using a provided mapping list (port_uuid, old_ct_zone, new_ct_zone).

## Manual Testing

- Testing results are documented here: https://docs.google.com/document/d/1kIUDR6MHAgBASPSjUHSeqdXUdwdMtRGr5qjdOXR1LK8/edit?tab=t.0

## Note

- Currently test files are not updated so the tests present in testfiles will fail for the time being.